### PR TITLE
Sample ad templates for debugging/coding in the ad manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 
 .DS_Store
 npm-debug.log
+templates/dist

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,17 @@
+{
+  "bitwise": true,
+  "browser": true,
+  "curly": true,
+  "eqeqeq": true,
+  "esnext": true,
+  "latedef": true,
+  "noarg": true,
+  "node": true,
+  "strict": true,
+  "undef": true,
+  "unused": true,
+  "globals": {
+    "angular": false
+  }
+}
+

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,29 @@
+/**
+ * Main entrypoint for grunt.
+ */
+'use strict';
+
+module.exports = function(grunt) {
+  require('./package.json');
+
+  var config = grunt.util._.extend(
+    require('load-grunt-config')(grunt, {
+      configPath: require('path').join(process.cwd(), 'tasks/options'),
+      init: false
+    })
+  );
+
+  grunt.initConfig(config);
+
+  grunt.loadTasks('tasks');
+
+  grunt.registerTask('build', function() {
+    grunt.task.run([
+      'browserify'
+    ]);
+  });
+
+  grunt.registerTask('serve', ['build', 'connect:livereload', 'watch']);
+
+  grunt.registerTask('default', ['serve']);
+};

--- a/package.json
+++ b/package.json
@@ -8,14 +8,23 @@
   "devDependencies": {
     "browserify": "^11.0.1",
     "chai": "^3.2.0",
+    "connect-modrewrite": "^0.8.2",
     "eslint": "^1.2.1",
+    "foundation-sites": "^6.0.3",
+    "grunt": "^0.4.5",
+    "grunt-browserify": "^4.0.1",
+    "grunt-cli": "^0.1.13",
+    "grunt-contrib-connect": "^0.11.2",
+    "grunt-contrib-watch": "^0.6.1",
     "karma": "^0.13.8",
     "karma-browserify": "^4.3.0",
     "karma-chai": "^0.1.0",
     "karma-mocha": "^0.2.0",
     "karma-phantomjs-launcher": "^0.2.1",
     "karma-sinon": "^1.0.4",
+    "load-grunt-config": "^0.19.0",
     "mocha": "^2.2.5",
+    "serve-static": "^1.10.0",
     "sinon": "^1.16.0"
   }
 }

--- a/src/manager.js
+++ b/src/manager.js
@@ -16,7 +16,7 @@ module.exports = {
 
     this.slots = {};
     this.adId = 0;
-    this.targeting = utils.extend({dfp_site: adUnits.settings.dfpSite}, global.TARGETING);
+    this.targeting = utils.extend({ dfp_site: adUnits.settings.dfpSite }, global.TARGETING);
     this.initialized = false;
 
     this.debugAds = {};

--- a/tasks/options/browserify.js
+++ b/tasks/options/browserify.js
@@ -1,0 +1,13 @@
+module.exports = {
+  browserify: {
+    files: {
+      'templates/dist/module.js': ['templates/js/ads.browserify.js']
+    },
+    options: {
+      alias: {
+        'bulbs.ads.units': './templates/js/adUnits.js',
+        'bulbs.ads.manager': './src/manager.js'
+      }
+    }
+  }
+}

--- a/tasks/options/connect.js
+++ b/tasks/options/connect.js
@@ -1,0 +1,26 @@
+/**
+ * Configurations for static web server.
+ */
+'use strict';
+
+module.exports = {
+  options: {
+    port: 9000,
+    hostname: 'localhost',
+    livereload: 35729
+  },
+  livereload: {
+    options: {
+      open: true,
+      port: 9000,
+      hostname: 'localhost',
+      base: {
+        path: './templates',
+        options: {
+          index: 'index.html',
+          maxAge: 300000
+        }
+      }
+    }
+  }
+};

--- a/tasks/options/jshint.js
+++ b/tasks/options/jshint.js
@@ -1,0 +1,15 @@
+/**
+ * JSHint linting.
+ */
+'use strict';
+
+module.exports = {
+  src: [
+    'src/**/*.js',
+    'tasks/**/*.js',
+    'Gruntfile.js'
+  ],
+  options: {
+    jshintrc: '.jshintrc'
+  }
+};

--- a/tasks/options/watch.js
+++ b/tasks/options/watch.js
@@ -1,0 +1,14 @@
+/**
+ * Watch directories for changes and redo tasks, livereload.
+ */
+'use strict';
+
+module.exports = {
+  scripts: {
+    files: ['src/*.js', 'templates/js/adUnits.js', 'index.html'],
+    tasks: ['build']
+  },
+  options: {
+    livereload: '<%= connect.options.livereload %>'
+  }
+};

--- a/templates/ads/billboard.html
+++ b/templates/ads/billboard.html
@@ -1,0 +1,72 @@
+<!doctype html>
+<html class="no-js" lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Billboard</title>
+  <link rel="stylesheet" href="http://dhbhdrzi4tiry.cloudfront.net/cdn/sites/foundation.min.css">
+  <style>
+    .home .dfp {
+      margin: 0 auto;
+      display: table;
+    }
+  </style>
+</head>
+  <body class="home">
+    <div class="top-bar">
+      <div class="top-bar-left">
+        <ul class="dropdown menu" data-dropdown-menu>
+          <li class="menu-text"><a href="../index.html">Home</a></li>
+          <li><a href="./cube.html">Cube</a></li>
+          <li><a href="./leaderboard.html">Leaderboard</a></li>
+          <li><a href="./billboard.html">Billboard</a></li>
+          <li><a href="./pushdown.html">Pushdown</a></li>
+          <li><a href="./wallpaper.html">Wallpaper</a></li>
+          <li class="has-submenu">
+            <a href="#">In-Banner Video</a>
+            <ul class="submenu menu vertical" data-submenu>
+              <li><a href="./billboard_video.html">Billboard</a></li>
+              <li><a href="./pushdown_video.html">Pushdown</a></li>
+              <li><a href="./wallpaper_video.html">Wallpaper</a></li>
+            </ul>
+          </li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="callout large primary">
+      <div class="row column text-center">
+        <h1>Ads Stuff</h1>
+        <h2 class="subheader">Such a Simple Billboard</h2>
+      </div>
+    </div>
+
+    <div class="dfp dfp-slot-header" data-ad-unit="header"></div>
+
+    <div class="blog-post medium-8 large-7 columns row">
+      <h3>Awesome blog post title <small>3/6/2015</small></h3>
+      <img class="thumbnail" src="http://placehold.it/850x350">
+      <p>Praesent id metus massa, ut blandit odio. Proin quis tortor orci. Etiam at risus et justo dignissim congue. Donec congue lacinia dui, a porttitor lectus condimentum laoreet. Nunc eu ullamcorper orci. Quisque eget odio ac lectus vestibulum faucibus eget in metus. In pellentesque faucibus vestibulum. Nulla at nulla justo, eget luctus.</p>
+      <p>Praesent id metus massa, ut blandit odio. Proin quis tortor orci. Etiam at risus et justo dignissim congue. Donec congue lacinia dui, a porttitor lectus condimentum laoreet. Nunc eu ullamcorper orci. Quisque eget odio ac lectus vestibulum faucibus eget in metus. In pellentesque faucibus vestibulum. Nulla at nulla justo, eget luctus.</p>
+      <p>Praesent id metus massa, ut blandit odio. Proin quis tortor orci. Etiam at risus et justo dignissim congue. Donec congue lacinia dui, a porttitor lectus condimentum laoreet. Nunc eu ullamcorper orci. Quisque eget odio ac lectus vestibulum faucibus eget in metus. In pellentesque faucibus vestibulum. Nulla at nulla justo, eget luctus.</p>
+      <p>Praesent id metus massa, ut blandit odio. Proin quis tortor orci. Etiam at risus et justo dignissim congue. Donec congue lacinia dui, a porttitor lectus condimentum laoreet. Nunc eu ullamcorper orci. Quisque eget odio ac lectus vestibulum faucibus eget in metus. In pellentesque faucibus vestibulum. Nulla at nulla justo, eget luctus.</p>
+      <div class="callout">
+        <ul class="menu simple">
+          <li><a href="#">Author: Mike Mikers</a></li>
+          <li><a href="#">Comments: 3</a></li>
+        </ul>
+      </div>
+    </div>
+    <script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+    <script src="http://dhbhdrzi4tiry.cloudfront.net/cdn/sites/foundation.js"></script>
+    <script>
+      window.TARGETING = {
+        dfp_site: 'onion',
+        dfp_pagetype: 'article',
+        dfp_test: 'billboard'
+      };
+      $(document).foundation();
+    </script>
+    <script src="../dist/module.js"></script>
+  </body>
+</html>

--- a/templates/ads/cube.html
+++ b/templates/ads/cube.html
@@ -1,0 +1,72 @@
+<!doctype html>
+<html class="no-js" lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Cube</title>
+  <link rel="stylesheet" href="http://dhbhdrzi4tiry.cloudfront.net/cdn/sites/foundation.min.css">
+  <style>
+    .home .dfp {
+      margin: 0 auto;
+      display: table;
+    }
+  </style>
+</head>
+  <body class="home">
+    <div class="top-bar">
+      <div class="top-bar-left">
+        <ul class="dropdown menu" data-dropdown-menu>
+          <li class="menu-text"><a href="../index.html">Home</a></li>
+          <li><a href="./cube.html">Cube</a></li>
+          <li><a href="./leaderboard.html">Leaderboard</a></li>
+          <li><a href="./billboard.html">Billboard</a></li>
+          <li><a href="./pushdown.html">Pushdown</a></li>
+          <li><a href="./wallpaper.html">Wallpaper</a></li>
+          <li class="has-submenu">
+            <a href="#">In-Banner Video</a>
+            <ul class="submenu menu vertical" data-submenu>
+              <li><a href="./billboard_video.html">Billboard</a></li>
+              <li><a href="./pushdown_video.html">Pushdown</a></li>
+              <li><a href="./wallpaper_video.html">Wallpaper</a></li>
+            </ul>
+          </li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="callout large primary">
+      <div class="row column text-center">
+        <h1>Ads Stuff</h1>
+        <h2 class="subheader">Such a Simple Cube</h2>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="blog-post medium-8 large-7 columns">
+        <h3>Awesome blog post title <small>3/6/2015</small></h3>
+        <img class="thumbnail" src="http://placehold.it/850x350">
+        <p>Praesent id metus massa, ut blandit odio. Proin quis tortor orci. Etiam at risus et justo dignissim congue. Donec congue lacinia dui, a porttitor lectus condimentum laoreet. Nunc eu ullamcorper orci. Quisque eget odio ac lectus vestibulum faucibus eget in metus. In pellentesque faucibus vestibulum. Nulla at nulla justo, eget luctus.</p>
+        <p>Praesent id metus massa, ut blandit odio. Proin quis tortor orci. Etiam at risus et justo dignissim congue. Donec congue lacinia dui, a porttitor lectus condimentum laoreet. Nunc eu ullamcorper orci. Quisque eget odio ac lectus vestibulum faucibus eget in metus. In pellentesque faucibus vestibulum. Nulla at nulla justo, eget luctus.</p>
+        <p>Praesent id metus massa, ut blandit odio. Proin quis tortor orci. Etiam at risus et justo dignissim congue. Donec congue lacinia dui, a porttitor lectus condimentum laoreet. Nunc eu ullamcorper orci. Quisque eget odio ac lectus vestibulum faucibus eget in metus. In pellentesque faucibus vestibulum. Nulla at nulla justo, eget luctus.</p>
+        <p>Praesent id metus massa, ut blandit odio. Proin quis tortor orci. Etiam at risus et justo dignissim congue. Donec congue lacinia dui, a porttitor lectus condimentum laoreet. Nunc eu ullamcorper orci. Quisque eget odio ac lectus vestibulum faucibus eget in metus. In pellentesque faucibus vestibulum. Nulla at nulla justo, eget luctus.</p>
+        <div class="callout">
+          <ul class="menu simple">
+            <li><a href="#">Author: Mike Mikers</a></li>
+            <li><a href="#">Comments: 3</a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="dfp dfp-slot-sidebar-primary medium-4 large-5 columns" data-ad-unit="sidebar-primary"></div>
+    </div>
+    <script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+    <script src="http://dhbhdrzi4tiry.cloudfront.net/cdn/sites/foundation.js"></script>
+    <script>
+      window.TARGETING = {
+        dfp_site: 'onion',
+        dfp_pagetype: 'article'
+      };
+      $(document).foundation();
+    </script>
+    <script src="../dist/module.js"></script>
+  </body>
+</html>

--- a/templates/ads/leaderboard.html
+++ b/templates/ads/leaderboard.html
@@ -1,0 +1,72 @@
+<!doctype html>
+<html class="no-js" lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Leaderboard</title>
+  <link rel="stylesheet" href="http://dhbhdrzi4tiry.cloudfront.net/cdn/sites/foundation.min.css">
+  <style>
+    .home .dfp {
+      margin: 0 auto;
+      display: table;
+    }
+  </style>
+</head>
+  <body class="home">
+    <div class="top-bar">
+      <div class="top-bar-left">
+        <ul class="dropdown menu" data-dropdown-menu>
+          <li class="menu-text"><a href="../index.html">Home</a></li>
+          <li><a href="./cube.html">Cube</a></li>
+          <li><a href="./leaderboard.html">Leaderboard</a></li>
+          <li><a href="./billboard.html">Billboard</a></li>
+          <li><a href="./pushdown.html">Pushdown</a></li>
+          <li><a href="./wallpaper.html">Wallpaper</a></li>
+          <li class="has-submenu">
+            <a href="#">In-Banner Video</a>
+            <ul class="submenu menu vertical" data-submenu>
+              <li><a href="./billboard_video.html">Billboard</a></li>
+              <li><a href="./pushdown_video.html">Pushdown</a></li>
+              <li><a href="./wallpaper_video.html">Wallpaper</a></li>
+            </ul>
+          </li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="callout large primary">
+      <div class="row column text-center">
+        <h1>Ads Stuff</h1>
+        <h2 class="subheader">Such a Simple Leaderboard</h2>
+      </div>
+    </div>
+
+    <div class="dfp dfp-slot-header" data-ad-unit="header"></div>
+
+    <div class="blog-post medium-8 large-7 columns row">
+      <h3>Awesome blog post title <small>3/6/2015</small></h3>
+      <img class="thumbnail" src="http://placehold.it/850x350">
+      <p>Praesent id metus massa, ut blandit odio. Proin quis tortor orci. Etiam at risus et justo dignissim congue. Donec congue lacinia dui, a porttitor lectus condimentum laoreet. Nunc eu ullamcorper orci. Quisque eget odio ac lectus vestibulum faucibus eget in metus. In pellentesque faucibus vestibulum. Nulla at nulla justo, eget luctus.</p>
+      <p>Praesent id metus massa, ut blandit odio. Proin quis tortor orci. Etiam at risus et justo dignissim congue. Donec congue lacinia dui, a porttitor lectus condimentum laoreet. Nunc eu ullamcorper orci. Quisque eget odio ac lectus vestibulum faucibus eget in metus. In pellentesque faucibus vestibulum. Nulla at nulla justo, eget luctus.</p>
+      <p>Praesent id metus massa, ut blandit odio. Proin quis tortor orci. Etiam at risus et justo dignissim congue. Donec congue lacinia dui, a porttitor lectus condimentum laoreet. Nunc eu ullamcorper orci. Quisque eget odio ac lectus vestibulum faucibus eget in metus. In pellentesque faucibus vestibulum. Nulla at nulla justo, eget luctus.</p>
+      <p>Praesent id metus massa, ut blandit odio. Proin quis tortor orci. Etiam at risus et justo dignissim congue. Donec congue lacinia dui, a porttitor lectus condimentum laoreet. Nunc eu ullamcorper orci. Quisque eget odio ac lectus vestibulum faucibus eget in metus. In pellentesque faucibus vestibulum. Nulla at nulla justo, eget luctus.</p>
+      <div class="callout">
+        <ul class="menu simple">
+          <li><a href="#">Author: Mike Mikers</a></li>
+          <li><a href="#">Comments: 3</a></li>
+        </ul>
+      </div>
+    </div>
+    <script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+    <script src="http://dhbhdrzi4tiry.cloudfront.net/cdn/sites/foundation.js"></script>
+    <script>
+      window.TARGETING = {
+        dfp_site: 'onion',
+        dfp_pagetype: 'article',
+        dfp_test: 'leaderboard'
+      };
+      $(document).foundation();
+    </script>
+    <script src="../dist/module.js"></script>
+  </body>
+</html>

--- a/templates/ads/pushdown.html
+++ b/templates/ads/pushdown.html
@@ -1,0 +1,72 @@
+<!doctype html>
+<html class="no-js" lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Pushdown</title>
+  <link rel="stylesheet" href="http://dhbhdrzi4tiry.cloudfront.net/cdn/sites/foundation.min.css">
+  <style>
+    .home .dfp {
+      margin: 0 auto;
+      display: table;
+    }
+  </style>
+</head>
+  <body class="home">
+    <div class="top-bar">
+      <div class="top-bar-left">
+        <ul class="dropdown menu" data-dropdown-menu>
+          <li class="menu-text"><a href="../index.html">Home</a></li>
+          <li><a href="./cube.html">Cube</a></li>
+          <li><a href="./leaderboard.html">Leaderboard</a></li>
+          <li><a href="./billboard.html">Billboard</a></li>
+          <li><a href="./pushdown.html">Pushdown</a></li>
+          <li><a href="./wallpaper.html">Wallpaper</a></li>
+          <li class="has-submenu">
+            <a href="#">In-Banner Video</a>
+            <ul class="submenu menu vertical" data-submenu>
+              <li><a href="./billboard_video.html">Billboard</a></li>
+              <li><a href="./pushdown_video.html">Pushdown</a></li>
+              <li><a href="./wallpaper_video.html">Wallpaper</a></li>
+            </ul>
+          </li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="callout large primary">
+      <div class="row column text-center">
+        <h1>Ads Stuff</h1>
+        <h2 class="subheader">Such a Simple Pushdown</h2>
+      </div>
+    </div>
+
+    <div class="dfp dfp-slot-header" data-ad-unit="header"></div>
+
+    <div class="blog-post medium-8 large-7 columns row">
+      <h3>Awesome blog post title <small>3/6/2015</small></h3>
+      <img class="thumbnail" src="http://placehold.it/850x350">
+      <p>Praesent id metus massa, ut blandit odio. Proin quis tortor orci. Etiam at risus et justo dignissim congue. Donec congue lacinia dui, a porttitor lectus condimentum laoreet. Nunc eu ullamcorper orci. Quisque eget odio ac lectus vestibulum faucibus eget in metus. In pellentesque faucibus vestibulum. Nulla at nulla justo, eget luctus.</p>
+      <p>Praesent id metus massa, ut blandit odio. Proin quis tortor orci. Etiam at risus et justo dignissim congue. Donec congue lacinia dui, a porttitor lectus condimentum laoreet. Nunc eu ullamcorper orci. Quisque eget odio ac lectus vestibulum faucibus eget in metus. In pellentesque faucibus vestibulum. Nulla at nulla justo, eget luctus.</p>
+      <p>Praesent id metus massa, ut blandit odio. Proin quis tortor orci. Etiam at risus et justo dignissim congue. Donec congue lacinia dui, a porttitor lectus condimentum laoreet. Nunc eu ullamcorper orci. Quisque eget odio ac lectus vestibulum faucibus eget in metus. In pellentesque faucibus vestibulum. Nulla at nulla justo, eget luctus.</p>
+      <p>Praesent id metus massa, ut blandit odio. Proin quis tortor orci. Etiam at risus et justo dignissim congue. Donec congue lacinia dui, a porttitor lectus condimentum laoreet. Nunc eu ullamcorper orci. Quisque eget odio ac lectus vestibulum faucibus eget in metus. In pellentesque faucibus vestibulum. Nulla at nulla justo, eget luctus.</p>
+      <div class="callout">
+        <ul class="menu simple">
+          <li><a href="#">Author: Mike Mikers</a></li>
+          <li><a href="#">Comments: 3</a></li>
+        </ul>
+      </div>
+    </div>
+    <script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+    <script src="http://dhbhdrzi4tiry.cloudfront.net/cdn/sites/foundation.js"></script>
+    <script>
+      window.TARGETING = {
+        dfp_site: 'onion',
+        dfp_pagetype: 'article',
+        dfp_test: 'pushdown'
+      };
+      $(document).foundation();
+    </script>
+    <script src="../dist/module.js"></script>
+  </body>
+</html>

--- a/templates/ads/wallpaper.html
+++ b/templates/ads/wallpaper.html
@@ -1,0 +1,115 @@
+<!doctype html>
+<html class="no-js" lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Wallpaper</title>
+  <link rel="stylesheet" href="http://dhbhdrzi4tiry.cloudfront.net/cdn/sites/foundation.min.css">
+  <style>
+    .home .dfp {
+      margin: 0 auto;
+    }
+
+    .dfp-slot-wallpaper {
+      max-height: 140px;
+      max-width: 1460px;
+      position: relative;
+    }
+
+    .dfp-slot-wallpaper:before {
+      display: block;
+      content: " ";
+      width: 100%;
+      padding-top: 9.5890411%;
+    }
+
+    .dfp-slot-wallpaper > div {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: initial;
+    }
+
+    .dfp-slot-wallpaper > div:before {
+      display: block;
+      content: " ";
+      width: 100%;
+      padding-top: 31.50684932%;
+    }
+
+    .dfp-slot-wallpaper iframe {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      height: 100%;
+      width: 100%;
+    }
+
+    .main-container:before, .main-container:after {
+      background-color: transparent;
+    }
+  </style>
+</head>
+  <body class="home">
+    <div class="top-bar">
+      <div class="top-bar-left">
+        <ul class="dropdown menu" data-dropdown-menu>
+          <li class="menu-text"><a href="../index.html">Home</a></li>
+          <li><a href="./cube.html">Cube</a></li>
+          <li><a href="./leaderboard.html">Leaderboard</a></li>
+          <li><a href="./billboard.html">Billboard</a></li>
+          <li><a href="./pushdown.html">Pushdown</a></li>
+          <li><a href="./wallpaper.html">Wallpaper</a></li>
+          <li class="has-submenu">
+            <a href="#">In-Banner Video</a>
+            <ul class="submenu menu vertical" data-submenu>
+              <li><a href="./billboard_video.html">Billboard</a></li>
+              <li><a href="./pushdown_video.html">Pushdown</a></li>
+              <li><a href="./wallpaper_video.html">Wallpaper</a></li>
+            </ul>
+          </li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="callout large primary">
+      <div class="row column text-center">
+        <h1>Ads Stuff</h1>
+        <h2 class="subheader">Such a Simple Wallpaper</h2>
+      </div>
+    </div>
+
+    <div class="dfp dfp-slot-wallpaper" data-ad-unit="wallpaper"></div>
+
+    <div class="main-container">
+      <div class="blog-post medium-8 large-7 columns row">
+        <h3>Awesome blog post title <small>3/6/2015</small></h3>
+        <img class="thumbnail" src="http://placehold.it/850x350">
+        <p>Praesent id metus massa, ut blandit odio. Proin quis tortor orci. Etiam at risus et justo dignissim congue. Donec congue lacinia dui, a porttitor lectus condimentum laoreet. Nunc eu ullamcorper orci. Quisque eget odio ac lectus vestibulum faucibus eget in metus. In pellentesque faucibus vestibulum. Nulla at nulla justo, eget luctus.</p>
+        <p>Praesent id metus massa, ut blandit odio. Proin quis tortor orci. Etiam at risus et justo dignissim congue. Donec congue lacinia dui, a porttitor lectus condimentum laoreet. Nunc eu ullamcorper orci. Quisque eget odio ac lectus vestibulum faucibus eget in metus. In pellentesque faucibus vestibulum. Nulla at nulla justo, eget luctus.</p>
+        <p>Praesent id metus massa, ut blandit odio. Proin quis tortor orci. Etiam at risus et justo dignissim congue. Donec congue lacinia dui, a porttitor lectus condimentum laoreet. Nunc eu ullamcorper orci. Quisque eget odio ac lectus vestibulum faucibus eget in metus. In pellentesque faucibus vestibulum. Nulla at nulla justo, eget luctus.</p>
+        <p>Praesent id metus massa, ut blandit odio. Proin quis tortor orci. Etiam at risus et justo dignissim congue. Donec congue lacinia dui, a porttitor lectus condimentum laoreet. Nunc eu ullamcorper orci. Quisque eget odio ac lectus vestibulum faucibus eget in metus. In pellentesque faucibus vestibulum. Nulla at nulla justo, eget luctus.</p>
+        <div class="callout">
+          <ul class="menu simple">
+            <li><a href="#">Author: Mike Mikers</a></li>
+            <li><a href="#">Comments: 3</a></li>
+          </ul>
+        </div>
+      </div>
+    </div>
+    <script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+    <script src="http://dhbhdrzi4tiry.cloudfront.net/cdn/sites/foundation.js"></script>
+    <script>
+      window.TARGETING = {
+        dfp_site: 'onion',
+        dfp_pagetype: 'article',
+        dfp_test: 'wallpaper'
+      };
+      $(document).foundation();
+    </script>
+    <script src="../dist/module.js"></script>
+  </body>
+</html>

--- a/templates/ads/yieldmo_home.html
+++ b/templates/ads/yieldmo_home.html
@@ -1,0 +1,72 @@
+<!doctype html>
+<html class="no-js" lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>YieldMo</title>
+  <link rel="stylesheet" href="http://dhbhdrzi4tiry.cloudfront.net/cdn/sites/foundation.min.css">
+  <style>
+    .home .dfp {
+      margin: 0 auto;
+      display: table;
+    }
+  </style>
+</head>
+  <body class="home">
+    <div class="top-bar">
+      <div class="top-bar-left">
+        <ul class="dropdown menu" data-dropdown-menu>
+          <li class="menu-text"><a href="../index.html">Home</a></li>
+          <li><a href="./cube.html">Cube</a></li>
+          <li><a href="./leaderboard.html">Leaderboard</a></li>
+          <li><a href="./billboard.html">Billboard</a></li>
+          <li><a href="./pushdown.html">Pushdown</a></li>
+          <li><a href="./wallpaper.html">Wallpaper</a></li>
+          <li class="has-submenu">
+            <a href="#">In-Banner Video</a>
+            <ul class="submenu menu vertical" data-submenu>
+              <li><a href="./billboard_video.html">Billboard</a></li>
+              <li><a href="./pushdown_video.html">Pushdown</a></li>
+              <li><a href="./wallpaper_video.html">Wallpaper</a></li>
+            </ul>
+          </li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="callout large primary">
+      <div class="row column text-center">
+        <h1>Ads Stuff</h1>
+        <h2 class="subheader">Such a Simple YieldMo setup</h2>
+      </div>
+    </div>
+
+    <div class="dfp dfp-slot-article-inbetween" data-ad-unit="article-inbetween"></div>
+
+    <div class="blog-post medium-8 large-7 columns row">
+      <h3>Awesome blog post title <small>3/6/2015</small></h3>
+      <img class="thumbnail" src="http://placehold.it/850x350">
+      <p>Praesent id metus massa, ut blandit odio. Proin quis tortor orci. Etiam at risus et justo dignissim congue. Donec congue lacinia dui, a porttitor lectus condimentum laoreet. Nunc eu ullamcorper orci. Quisque eget odio ac lectus vestibulum faucibus eget in metus. In pellentesque faucibus vestibulum. Nulla at nulla justo, eget luctus.</p>
+      <p>Praesent id metus massa, ut blandit odio. Proin quis tortor orci. Etiam at risus et justo dignissim congue. Donec congue lacinia dui, a porttitor lectus condimentum laoreet. Nunc eu ullamcorper orci. Quisque eget odio ac lectus vestibulum faucibus eget in metus. In pellentesque faucibus vestibulum. Nulla at nulla justo, eget luctus.</p>
+      <p>Praesent id metus massa, ut blandit odio. Proin quis tortor orci. Etiam at risus et justo dignissim congue. Donec congue lacinia dui, a porttitor lectus condimentum laoreet. Nunc eu ullamcorper orci. Quisque eget odio ac lectus vestibulum faucibus eget in metus. In pellentesque faucibus vestibulum. Nulla at nulla justo, eget luctus.</p>
+      <p>Praesent id metus massa, ut blandit odio. Proin quis tortor orci. Etiam at risus et justo dignissim congue. Donec congue lacinia dui, a porttitor lectus condimentum laoreet. Nunc eu ullamcorper orci. Quisque eget odio ac lectus vestibulum faucibus eget in metus. In pellentesque faucibus vestibulum. Nulla at nulla justo, eget luctus.</p>
+      <div class="callout">
+        <ul class="menu simple">
+          <li><a href="#">Author: Mike Mikers</a></li>
+          <li><a href="#">Comments: 3</a></li>
+        </ul>
+      </div>
+    </div>
+    <div class="dfp dfp-slot-article-inbetween" data-ad-unit="article-inbetween"></div>
+    <script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+    <script src="http://dhbhdrzi4tiry.cloudfront.net/cdn/sites/foundation.js"></script>
+    <script>
+      window.TARGETING = {
+        dfp_site: 'onion',
+        dfp_pagetype: 'article'
+      };
+      $(document).foundation();
+    </script>
+    <script src="../dist/module.js"></script>
+  </body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,126 @@
+<!doctype html>
+<html class="no-js" lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Foundation | Welcome</title>
+  <link rel="stylesheet" href="http://dhbhdrzi4tiry.cloudfront.net/cdn/sites/foundation.min.css">
+  <style>
+    .home .dfp {
+      margin: 0 auto;
+      display: table;
+    }
+  </style>
+</head>
+  <body class="home">
+    <div class="top-bar">
+      <div class="top-bar-left">
+        <ul class="dropdown menu" data-dropdown-menu>
+          <li class="menu-text"><a href="#">Home</a></li>
+          <li><a href="./ads/cube.html">Cube</a></li>
+          <li><a href="./ads/leaderboard.html">Leaderboard</a></li>
+          <li><a href="./ads/billboard.html">Billboard</a></li>
+          <li><a href="./ads/pushdown.html">Pushdown</a></li>
+          <li><a href="./ads/wallpaper.html">Wallpaper</a></li>
+          <li class="has-submenu">
+            <a href="#">In-Banner Video</a>
+            <ul class="submenu menu vertical" data-submenu>
+              <li><a href="./ads/billboard_video.html">Billboard</a></li>
+              <li><a href="./ads/pushdown_video.html">Pushdown</a></li>
+              <li><a href="./ads/wallpaper_video.html">Wallpaper</a></li>
+            </ul>
+          </li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="callout large primary">
+      <div class="row column text-center">
+        <h1>Our Blog</h1>
+        <h2 class="subheader">Such a Simple Blog Layout</h2>
+      </div>
+    </div>
+
+    <div class="dfp dfp-slot-header" data-ad-unit="header"></div>
+
+    <div class="row medium-8 large-7 columns">
+      <div class="blog-post">
+        <h3>Awesome blog post title <small>3/6/2015</small></h3>
+        <img class="thumbnail" src="http://placehold.it/850x350">
+        <p>Praesent id metus massa, ut blandit odio. Proin quis tortor orci. Etiam at risus et justo dignissim congue. Donec congue lacinia dui, a porttitor lectus condimentum laoreet. Nunc eu ullamcorper orci. Quisque eget odio ac lectus vestibulum faucibus eget in metus. In pellentesque faucibus vestibulum. Nulla at nulla justo, eget luctus.</p>
+        <div class="callout">
+          <ul class="menu simple">
+            <li><a href="#">Author: Mike Mikers</a></li>
+            <li><a href="#">Comments: 3</a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="dfp dfp-slot-yieldmo" data-ad-unit="yieldmo"></div>
+      <div class="blog-post">
+        <h3>Awesome blog post title <small>3/6/2015</small></h3>
+        <img class="thumbnail" src="http://placehold.it/850x350">
+        <p>Praesent id metus massa, ut blandit odio. Proin quis tortor orci. Etiam at risus et justo dignissim congue. Donec congue lacinia dui, a porttitor lectus condimentum laoreet. Nunc eu ullamcorper orci. Quisque eget odio ac lectus vestibulum faucibus eget in metus. In pellentesque faucibus vestibulum. Nulla at nulla justo, eget luctus.</p>
+        <div class="callout">
+          <ul class="menu simple">
+            <li><a href="#">Author: Mike Mikers</a></li>
+            <li><a href="#">Comments: 3</a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="blog-post">
+        <h3>Awesome blog post title <small>3/6/2015</small></h3>
+        <img class="thumbnail" src="http://placehold.it/850x350">
+        <p>Praesent id metus massa, ut blandit odio. Proin quis tortor orci. Etiam at risus et justo dignissim congue. Donec congue lacinia dui, a porttitor lectus condimentum laoreet. Nunc eu ullamcorper orci. Quisque eget odio ac lectus vestibulum faucibus eget in metus. In pellentesque faucibus vestibulum. Nulla at nulla justo, eget luctus.</p>
+        <div class="callout">
+          <ul class="menu simple">
+            <li><a href="#">Author: Mike Mikers</a></li>
+            <li><a href="#">Comments: 3</a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="blog-post">
+        <h3>Awesome blog post title <small>3/6/2015</small></h3>
+        <img class="thumbnail" src="http://placehold.it/850x350">
+        <p>Praesent id metus massa, ut blandit odio. Proin quis tortor orci. Etiam at risus et justo dignissim congue. Donec congue lacinia dui, a porttitor lectus condimentum laoreet. Nunc eu ullamcorper orci. Quisque eget odio ac lectus vestibulum faucibus eget in metus. In pellentesque faucibus vestibulum. Nulla at nulla justo, eget luctus.</p>
+        <div class="callout">
+          <ul class="menu simple">
+            <li><a href="#">Author: Mike Mikers</a></li>
+            <li><a href="#">Comments: 3</a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="blog-post">
+        <h3>Awesome blog post title <small>3/6/2015</small></h3>
+        <img class="thumbnail" src="http://placehold.it/850x350">
+        <p>Praesent id metus massa, ut blandit odio. Proin quis tortor orci. Etiam at risus et justo dignissim congue. Donec congue lacinia dui, a porttitor lectus condimentum laoreet. Nunc eu ullamcorper orci. Quisque eget odio ac lectus vestibulum faucibus eget in metus. In pellentesque faucibus vestibulum. Nulla at nulla justo, eget luctus.</p>
+        <div class="callout">
+          <ul class="menu simple">
+            <li><a href="#">Author: Mike Mikers</a></li>
+            <li><a href="#">Comments: 3</a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="blog-post">
+        <h3>Awesome blog post title <small>3/6/2015</small></h3>
+        <img class="thumbnail" src="http://placehold.it/850x350">
+        <p>Praesent id metus massa, ut blandit odio. Proin quis tortor orci. Etiam at risus et justo dignissim congue. Donec congue lacinia dui, a porttitor lectus condimentum laoreet. Nunc eu ullamcorper orci. Quisque eget odio ac lectus vestibulum faucibus eget in metus. In pellentesque faucibus vestibulum. Nulla at nulla justo, eget luctus.</p>
+        <div class="callout">
+          <ul class="menu simple">
+            <li><a href="#">Author: Mike Mikers</a></li>
+            <li><a href="#">Comments: 3</a></li>
+          </ul>
+        </div>
+      </div>
+    </div>
+    <script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+    <script src="http://dhbhdrzi4tiry.cloudfront.net/cdn/sites/foundation.js"></script>
+    <script>
+      window.TARGETING = {
+        dfp_site: 'onion',
+        dfp_pagetype: 'home'
+      };
+      $(document).foundation();
+    </script>
+    <script src="../dist/module.js"></script>
+  </body>
+</html>

--- a/templates/js/adUnits.js
+++ b/templates/js/adUnits.js
@@ -1,0 +1,91 @@
+var AdUnits = {
+  settings: {
+    dfpSite: 'onion',
+    closeDelay: 1250
+  }
+};
+
+AdUnits.units = {
+  // This is used at the top of the homepage, as well as at the start of every article
+  'header': {
+    'slotName': 'header',
+    'sizes': [
+      [[970, 0], [[728, 90], [970, 415], [970, 250], [970, 90], [970, 66], [970, 418]]],
+      [[728, 0], [728, 90]],
+      [[0, 0], [320, 50]]
+    ]
+  },
+
+  // Homepage 728's
+  'homepage-secondary': {
+    'slotName': 'homepage-secondary',
+    'sizes': [
+      [[1240, 0], [728, 90]],
+
+      [[0, 0], [320, 50]]
+      // viewport above needs to be 1370 for .large-thing
+      // to accommodate a 728x90 slot
+    ]
+  },
+  'homepage-tertiary': {
+    'slotName': 'homepage-tertiary',
+    'sizes': [
+      [[1240, 0], [728, 90]],
+      [[400, 0], [320, 50]],
+      [[0, 0], []]
+      // viewport above needs to be 1370 for .large-thing
+      // to accommodate a 728x90 slot
+    ]
+  },
+
+  // This one shows up on the homepage & article pages
+  'sidebar-primary': {
+    'slotName': 'sidebar-primary',
+    'sizes': [
+      [[1000, 0], [300, 250]],
+      [[0, 0], []],
+    ]
+  },
+
+  // Secondary and tertiary only show up on the homepage
+  'sidebar-secondary': {
+    'slotName': 'sidebar-secondary',
+    'sizes': [
+      [[0, 0], [300, 250]],
+    ]
+  },
+
+  // Tertiary only shows up on the homepage, tablet and up
+  'sidebar-tertiary': {
+    'slotName': 'sidebar-tertiary',
+    'sizes': [
+      [[1240, 0], [300, 250]],
+      [[0, 0], []]
+    ]
+  },
+
+  'wallpaper': {
+    slotName: 'wallpaper',
+    sizes: [
+      [[970, 0], [1, 1]],
+      [[0, 0], []]
+    ]
+  },
+
+  'inread': {
+    'slotName': 'inread',
+    'sizes': [
+      [[0,0], [1,1]]
+    ]
+  },
+
+  'yieldmo': {
+    'slotName': 'article-inbetween',
+    'sizes': [
+      [[0,0], [300,250]]
+    ]
+  },
+
+};
+
+module.exports = AdUnits;

--- a/templates/js/ads.browserify.js
+++ b/templates/js/ads.browserify.js
@@ -1,0 +1,3 @@
+window.ads = require('bulbs.ads.manager');
+
+ads.init();

--- a/templates/js/ads.browserify.js
+++ b/templates/js/ads.browserify.js
@@ -1,3 +1,2 @@
-window.ads = require('bulbs.ads.manager');
-
-ads.init();
+var AdManager = require('bulbs.ads.manager');
+window.ads = new AdManager();


### PR DESCRIPTION
This makes it a lot easier to debug against the ads manager code without leaving the repo.  @kand @collin.  Note, if you wanted to take a look, easiest to pull down the repo and run `grunt`.  It will open up a browser with live reload and you can jump between testing different types of creative and how they work with the ads manager lib.

It's purposely rudimentary on the template side.
