### PR TITLE
remove filter by viewport code

### DIFF
--- a/src/manager.js
+++ b/src/manager.js
@@ -11,7 +11,6 @@ var AdManager = function(options) {
     resizeTimeout: null,
     debug: false,
     dfpId: 1009948,
-    filterSlotsByViewport: false
   };
   var options = options || {};
 
@@ -85,9 +84,6 @@ AdManager.prototype.initGoogleTag = function() {
   this.initialized = true;
 
   this.loadAds();
-  if (this.options.filterSlotsByViewport) {
-    setInterval(adManager.loadAds, 200);
-  }
 };
 
 /**
@@ -190,32 +186,6 @@ AdManager.prototype.findAds = function (el) {
   }
 
   return ads;
-};
-
-/**
- * Filter ads on the page by viewport threshold, if enabled
- *
- * @param {HTMLCollection} ads - Array of ads to confirm if within viewport
- * @returns {Array} of {Element} objects representing filtered ad slots
-*/
-AdManager.prototype.filterAds = function(ads) {
-  if (this.options.filterSlotsByViewport) {
-    var filteredAds = [];
-    var nearViewport;
-    for (var i = 0, l = ads.length; i < l; i ++) {
-      var ad = ads[i];
-      nearViewport = utils.elementNearViewport(ad, {
-        withinDistance: this.options.viewportThreshold
-      });
-      if (nearViewport) {
-        filteredAds.push(ad);
-      }
-    }
-    return filteredAds;
-  }
-  else {
-    return ads;
-  }
 };
 
 AdManager.prototype.logMessage = function(message, logLevel) {
@@ -347,8 +317,8 @@ AdManager.prototype.loadAds = function(element) {
     return;
   }
 
-  var ads = this.filterAds(this.findAds(element));
   var slotsToLoad = [];
+  var ads = this.findAds(element);
 
   if (!this.googletag.pubadsReady) {
     this.googletag.enableServices();

--- a/src/manager.spec.js
+++ b/src/manager.spec.js
@@ -37,10 +37,6 @@ describe('AdManager', function() {
       it('reloads on resize', function() {
         expect(adManager.options.doReloadOnResize).to.be.true;
       });
-
-      it('sets filter slots by viewport based on ad unit config', function() {
-        expect(adManager.options.filterSlotsByViewport).to.be.false;
-      });
     });
 
     context('override options', function() {
@@ -127,16 +123,6 @@ describe('AdManager', function() {
 
     it('loads ads initially', function() {
       expect(adManager.loadAds.calledOnce).to.be.true;
-    });
-
-    it('calls loadAds on an interval if filtering by viewport', function(done) {
-      adManager.options.filterSlotsByViewport = true;
-      adManager.loadAds.reset();
-      adManager.initGoogleTag();
-      setTimeout(function() {
-        expect(adManager.loadAds.callCount).to.be.greaterThan(1);
-        done();
-      }, 300);
     });
   });
 
@@ -358,70 +344,6 @@ describe('AdManager', function() {
       });
     });
   });
-
-  describe('#filterAds', function() {
-    var adSlot1, container1;
-
-    beforeEach(function() {
-      container1 = document.createElement('div');
-      adSlot1 = document.createElement('div');
-      adSlot1.id = 'dfp-ad-1';
-      adSlot1.className = 'dfp';
-      container1.appendChild(adSlot1);
-      document.body.appendChild(container1);
-    });
-
-    afterEach(function() {
-      $(container1).remove();
-    });
-
-    context('not filtering by viewport', function() {
-      var ads;
-
-      beforeEach(function() {
-        adManager.options.filterSlotsByViewport = false;
-        ads = adManager.filterAds([adSlot1]);
-      });
-
-      it('returns the ads untouched', function() {
-        expect(ads).to.eql([adSlot1]);
-      });
-    });
-
-    context('filtering by viewport', function() {
-      beforeEach(function() {
-        adManager.options.filterSlotsByViewport = true;
-        adManager.options.viewportThreshold = 200;
-      });
-
-      context('outside the viewport', function() {
-        beforeEach(function() {
-          var outsideTop = window.innerHeight + 400;
-          adSlot1.style.position = 'absolute';
-          adSlot1.style.top = outsideTop + 'px';
-          ads = adManager.filterAds([adSlot1]);
-        });
-
-        it('returns []', function() {
-          expect(ads).to.eql([]);
-        });
-      });
-
-      context('inside the viewport', function() {
-        beforeEach(function() {
-          var centeredTop = Math.round(window.innerHeight / 2);
-          adSlot1.style.position = 'absolute';
-          adSlot1.style.top = centeredTop + 'px';
-          ads = adManager.filterAds([adSlot1]);
-        });
-
-        it('returns ads', function() {
-          expect(ads).to.eql([adSlot1]);
-        });
-      });
-    });
-  });
-
   describe('#logMessage', function() {
     beforeEach(function() {
       TestHelper.spyOn(console, 'warn');


### PR DESCRIPTION
Removes code for filtering ad slots by viewport.

This will be obsoleted by the `<bulbs-dfp>` element.