### PR TITLE
Mobile page push

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,15 @@ $ npm test
 ### Notes
 #### Dependencies
 This project should never have outside, frontend dependencies since it really should be one of, if not, _the_ first JS to run on the page. Otherwise, potential ad views could be lost.
+
+## Creating a new release
+
+* inside of your ```bower.json``` and ```package.json``` files update the version in accordance with [semver](http://semver.org/)
+* Create a tag for your release
+```bash
+$ git tag <tag version number>
+```
+* push tag
+```bash
+$ git push origin --tags
+```

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "bulbs-public-ads-manager",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "private": true,
   "authors": [
     "Andrew Kos <akos@theonion.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bulbs-public-ads-manager",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Do not install via npm.",
   "private": false,
   "scripts": {

--- a/src/ad-units.js
+++ b/src/ad-units.js
@@ -76,15 +76,15 @@ var AdUnits = {
 
   handleMobileHeaderSlot: function(e, el) {
     var parent = el.parentElement;
+    AdUnits.makeAdTogglable(el);
+    if (!utils.hasClass(parent, 'header-wrapper')) {
+      return;
+    }
 
     AdUnits.setupMobileSlotClasses(e, el);
-    AdUnits.handlePagePushHeaderSlot(e, el);
   },
 
   handleLeaderboardHeaderSlot: function(e, el) {
-    var parent = el.parentElement;
-    utils.removeClass(parent, 'page-push');
-
     AdUnits.makeAdTogglable(el);
   },
 
@@ -120,7 +120,7 @@ var AdUnits = {
     var parent = el.parentElement;
     AdUnits.resetClasses(parent);
 
-    if (e.size[0] === 300) {
+    if (e.size[0] === 320) {
       AdUnits.handleMobileHeaderSlot(e, el);
     } else if ((e.size[0] === 728) && (e.size[1] === 90)) {
       AdUnits.handleLeaderboardHeaderSlot(e, el);
@@ -142,7 +142,7 @@ AdUnits.units = {
     'sizes': [
       [[970, 0], [[728, 90], [1,1], [970, 415], [970, 250], [970, 90]]],
       [[728, 0], [[1,1], [728, 90]]],
-      [[0, 0], [[1,1], [300, 250]]]
+      [[0, 0], [[1,1], [320, 50], [300, 250]]]
     ],
     onSlotRenderEnded: AdUnits.headerSlotRenderEnded
   },

--- a/src/ad-units.js
+++ b/src/ad-units.js
@@ -76,9 +76,6 @@ var AdUnits = {
 
   handleMobileHeaderSlot: function(e, el) {
     var parent = el.parentElement;
-    if (!utils.hasClass(parent, 'header-wrapper')) {
-      return;
-    }
 
     AdUnits.setupMobileSlotClasses(e, el);
     AdUnits.handlePagePushHeaderSlot(e, el);

--- a/src/ad-units.js
+++ b/src/ad-units.js
@@ -68,6 +68,7 @@ var AdUnits = {
   setupMobileSlotClasses: function(e, el) {
     var parent = el.parentElement;
     utils.addClass(parent, 'mobile');
+    utils.addClass(parent, 'page-push');
 
     if (AdUnits.isKargo(e)) {
       utils.addClass(parent, 'kargo');
@@ -76,7 +77,6 @@ var AdUnits = {
 
   handleMobileHeaderSlot: function(e, el) {
     var parent = el.parentElement;
-    AdUnits.makeAdTogglable(el);
     if (!utils.hasClass(parent, 'header-wrapper')) {
       return;
     }
@@ -120,7 +120,7 @@ var AdUnits = {
     var parent = el.parentElement;
     AdUnits.resetClasses(parent);
 
-    if (e.size[0] === 320) {
+    if (e.size[0] === 300) {
       AdUnits.handleMobileHeaderSlot(e, el);
     } else if ((e.size[0] === 728) && (e.size[1] === 90)) {
       AdUnits.handleLeaderboardHeaderSlot(e, el);
@@ -142,7 +142,7 @@ AdUnits.units = {
     'sizes': [
       [[970, 0], [[728, 90], [1,1], [970, 415], [970, 250], [970, 90]]],
       [[728, 0], [[1,1], [728, 90]]],
-      [[0, 0], [[1,1], [320, 50]]]
+      [[0, 0], [[1,1], [300, 250]]]
     ],
     onSlotRenderEnded: AdUnits.headerSlotRenderEnded
   },

--- a/src/ad-units.js
+++ b/src/ad-units.js
@@ -82,6 +82,9 @@ var AdUnits = {
   },
 
   handleLeaderboardHeaderSlot: function(e, el) {
+    var parent = el.parentElement;
+    utils.removeClass(parent, 'page-push');
+
     AdUnits.makeAdTogglable(el);
   },
 

--- a/src/ad-units.js
+++ b/src/ad-units.js
@@ -68,7 +68,6 @@ var AdUnits = {
   setupMobileSlotClasses: function(e, el) {
     var parent = el.parentElement;
     utils.addClass(parent, 'mobile');
-    utils.addClass(parent, 'page-push');
 
     if (AdUnits.isKargo(e)) {
       utils.addClass(parent, 'kargo');
@@ -82,6 +81,7 @@ var AdUnits = {
     }
 
     AdUnits.setupMobileSlotClasses(e, el);
+    AdUnits.handlePagePushHeaderSlot(e, el);
   },
 
   handleLeaderboardHeaderSlot: function(e, el) {

--- a/src/ad-units.spec.js
+++ b/src/ad-units.spec.js
@@ -219,70 +219,66 @@ describe('Ad Units', function() {
 
   describe('#handleMobileHeaderSlot', function() {
     var parentAdElement;
-    var adIframe;
-    var e = {
-      slot: {
-        getSlotElementId: function() {
-          return 'ad-slot';
-        }
-      }
-    };
+    var e = {};
 
     beforeEach(function() {
       parentAdElement = document.createElement('div');
       adElement = document.createElement('div');
       adElement.id = 'ad-slot';
-      adElement.className = 'collapsed';
-      adIframe = document.createElement('iframe');
-      adElement.appendChild(adIframe);
       parentAdElement.appendChild(adElement);
       $('body').append(parentAdElement);
-      TestHelper.stub(adUnits, 'prepPagePushIframe');
-      parentAdElement.appendChild(adElement);
-      $('body').append(parentAdElement);
-
-      $(parentAdElement).addClass('header-wrapper');
     });
 
     afterEach(function() {
       document.body.removeChild(parentAdElement);
     });
 
+    describe('parent does not have `header-wrapper`', function() {
+      it('does not setup mobile slot classes', function() {
+        sinon.stub(adUnits, 'setupMobileSlotClasses');
+        adUnits.handleMobileHeaderSlot(e, adElement);
+        expect(adUnits.setupMobileSlotClasses.called).to.be.false;
+      });
 
-    it('sets up mobile slot classes', function() {
-      sinon.stub(adUnits, 'setupMobileSlotClasses');
-      adUnits.handleMobileHeaderSlot(e, adElement);
-      expect(adUnits.setupMobileSlotClasses.calledWith(e, adElement)).to.be.true;
+      it('makes ad togglable', function() {
+        sinon.stub(adUnits, 'makeAdTogglable');
+        adUnits.handleMobileHeaderSlot(e, adElement);
+        expect(adUnits.makeAdTogglable.calledWith(adElement)).to.be.true;
+      });
+    });
+
+    describe('parent has header wrapper', function() {
+      beforeEach(function() {
+        $(parentAdElement).addClass('header-wrapper');
+        adUnits.handleMobileHeaderSlot(e, adElement);
+      });
+
+      it('makes ad closeable', function() {
+        expect(adUnits.makeAdTogglable.calledWith(adElement)).to.be.true;
+      });
+
+      it('sets up mobile slot classes', function() {
+        expect(adUnits.setupMobileSlotClasses.calledWith(e, adElement)).to.be.true;
+      });
     });
   });
 
   describe('#handleLeaderboardHeaderSlot', function() {
     var parentAdElement;
-    var adElement;
     var e = {};
 
     beforeEach(function() {
-      sinon.stub(adUnits, 'makeAdTogglable');
       parentAdElement = document.createElement('div');
-      $(parentAdElement).addClass('page-push');
-      adElement = document.createElement('div');
-      $(parentAdElement).append(adElement);
       $('body').append(parentAdElement);
-      adUnits.handleLeaderboardHeaderSlot(e, adElement);
+      adUnits.handleLeaderboardHeaderSlot(e, parentAdElement);
     });
 
     afterEach(function() {
       document.body.removeChild(parentAdElement);
-      adUnits.makeAdTogglable.restore();
     });
 
     it('makes the ad closeable', function() {
-      expect(adUnits.makeAdTogglable.calledWith(adElement)).to.be.true;
-    });
-
-    it('removes page push class', function() {
-      var parentAdElementClass = $(parentAdElement).attr('class')
-      expect(parentAdElementClass === 'page-push').to.be.false;
+      expect(adUnits.makeAdTogglable.calledWith(parentAdElement)).to.be.true;
     });
   });
 
@@ -390,9 +386,9 @@ describe('Ad Units', function() {
       expect(adUnits.resetClasses.calledWith(parentAdElement)).to.be.true;
     });
 
-    it('defers to `handleMobileHeaderSlot` if 300x250', function() {
+    it('defers to `handleMobileHeaderSlot` if 320x50', function() {
       sinon.stub(adUnits, 'handleMobileHeaderSlot');
-      var e = { size: [300, 250]};
+      var e = { size: [320, 50]};
       adUnits.headerSlotRenderEnded(e, adElement);
       expect(adUnits.handleMobileHeaderSlot.calledWith(e, adElement)).to.be.true;
     });
@@ -419,7 +415,7 @@ describe('Ad Units', function() {
     });
 
     it('allows these slots on mobile', function() {
-      expect(adUnits.units.header.sizes[2]).to.eql([[0, 0], [[1,1], [300, 250]]]);
+      expect(adUnits.units.header.sizes[2]).to.eql([[0, 0], [[1,1], [320, 50], [300, 250]]]);
     });
 
     it('sets up `headerSlotRenderEnded` as the callback', function() {

--- a/src/ad-units.spec.js
+++ b/src/ad-units.spec.js
@@ -219,12 +219,25 @@ describe('Ad Units', function() {
 
   describe('#handleMobileHeaderSlot', function() {
     var parentAdElement;
-    var e = {};
+    var adIframe;
+    var e = {
+      slot: {
+        getSlotElementId: function() {
+          return 'ad-slot';
+        }
+      }
+    };
 
     beforeEach(function() {
       parentAdElement = document.createElement('div');
       adElement = document.createElement('div');
       adElement.id = 'ad-slot';
+      adElement.className = 'collapsed';
+      adIframe = document.createElement('iframe');
+      adElement.appendChild(adIframe);
+      parentAdElement.appendChild(adElement);
+      $('body').append(parentAdElement);
+      TestHelper.stub(adUnits, 'prepPagePushIframe');
       parentAdElement.appendChild(adElement);
       $('body').append(parentAdElement);
     });

--- a/src/ad-units.spec.js
+++ b/src/ad-units.spec.js
@@ -239,22 +239,12 @@ describe('Ad Units', function() {
         adUnits.handleMobileHeaderSlot(e, adElement);
         expect(adUnits.setupMobileSlotClasses.called).to.be.false;
       });
-
-      it('makes ad togglable', function() {
-        sinon.stub(adUnits, 'makeAdTogglable');
-        adUnits.handleMobileHeaderSlot(e, adElement);
-        expect(adUnits.makeAdTogglable.calledWith(adElement)).to.be.true;
-      });
     });
 
     describe('parent has header wrapper', function() {
       beforeEach(function() {
         $(parentAdElement).addClass('header-wrapper');
         adUnits.handleMobileHeaderSlot(e, adElement);
-      });
-
-      it('makes ad closeable', function() {
-        expect(adUnits.makeAdTogglable.calledWith(adElement)).to.be.true;
       });
 
       it('sets up mobile slot classes', function() {
@@ -268,6 +258,7 @@ describe('Ad Units', function() {
     var e = {};
 
     beforeEach(function() {
+      sinon.stub(adUnits, 'makeAdTogglable');
       parentAdElement = document.createElement('div');
       $('body').append(parentAdElement);
       adUnits.handleLeaderboardHeaderSlot(e, parentAdElement);
@@ -386,9 +377,9 @@ describe('Ad Units', function() {
       expect(adUnits.resetClasses.calledWith(parentAdElement)).to.be.true;
     });
 
-    it('defers to `handleMobileHeaderSlot` if 320x50', function() {
+    it('defers to `handleMobileHeaderSlot` if 300x250', function() {
       sinon.stub(adUnits, 'handleMobileHeaderSlot');
-      var e = { size: [320, 50]};
+      var e = { size: [300, 250]};
       adUnits.headerSlotRenderEnded(e, adElement);
       expect(adUnits.handleMobileHeaderSlot.calledWith(e, adElement)).to.be.true;
     });
@@ -415,7 +406,7 @@ describe('Ad Units', function() {
     });
 
     it('allows these slots on mobile', function() {
-      expect(adUnits.units.header.sizes[2]).to.eql([[0, 0], [[1,1], [320, 50]]]);
+      expect(adUnits.units.header.sizes[2]).to.eql([[0, 0], [[1,1], [300, 250]]]);
     });
 
     it('sets up `headerSlotRenderEnded` as the callback', function() {

--- a/src/ad-units.spec.js
+++ b/src/ad-units.spec.js
@@ -258,21 +258,31 @@ describe('Ad Units', function() {
 
   describe('#handleLeaderboardHeaderSlot', function() {
     var parentAdElement;
+    var adElement;
     var e = {};
 
     beforeEach(function() {
       sinon.stub(adUnits, 'makeAdTogglable');
       parentAdElement = document.createElement('div');
+      $(parentAdElement).addClass('page-push');
+      adElement = document.createElement('div');
+      $(parentAdElement).append(adElement);
       $('body').append(parentAdElement);
-      adUnits.handleLeaderboardHeaderSlot(e, parentAdElement);
+      adUnits.handleLeaderboardHeaderSlot(e, adElement);
     });
 
     afterEach(function() {
       document.body.removeChild(parentAdElement);
+      adUnits.makeAdTogglable.restore();
     });
 
     it('makes the ad closeable', function() {
-      expect(adUnits.makeAdTogglable.calledWith(parentAdElement)).to.be.true;
+      expect(adUnits.makeAdTogglable.calledWith(adElement)).to.be.true;
+    });
+
+    it('removes page push class', function() {
+      var parentAdElementClass = $(parentAdElement).attr('class')
+      expect(parentAdElementClass === 'page-push').to.be.false;
     });
   });
 

--- a/src/ad-units.spec.js
+++ b/src/ad-units.spec.js
@@ -240,29 +240,19 @@ describe('Ad Units', function() {
       TestHelper.stub(adUnits, 'prepPagePushIframe');
       parentAdElement.appendChild(adElement);
       $('body').append(parentAdElement);
+
+      $(parentAdElement).addClass('header-wrapper');
     });
 
     afterEach(function() {
       document.body.removeChild(parentAdElement);
     });
 
-    describe('parent does not have `header-wrapper`', function() {
-      it('does not setup mobile slot classes', function() {
-        sinon.stub(adUnits, 'setupMobileSlotClasses');
-        adUnits.handleMobileHeaderSlot(e, adElement);
-        expect(adUnits.setupMobileSlotClasses.called).to.be.false;
-      });
-    });
 
-    describe('parent has header wrapper', function() {
-      beforeEach(function() {
-        $(parentAdElement).addClass('header-wrapper');
-        adUnits.handleMobileHeaderSlot(e, adElement);
-      });
-
-      it('sets up mobile slot classes', function() {
-        expect(adUnits.setupMobileSlotClasses.calledWith(e, adElement)).to.be.true;
-      });
+    it('sets up mobile slot classes', function() {
+      sinon.stub(adUnits, 'setupMobileSlotClasses');
+      adUnits.handleMobileHeaderSlot(e, adElement);
+      expect(adUnits.setupMobileSlotClasses.calledWith(e, adElement)).to.be.true;
     });
   });
 


### PR DESCRIPTION
# Update

Articles pages on `Onion`, `Clickhole`, and `Avclub` should now be rendering a page push dfp slot instead of a pinned ad.
# Verification

Article pages should now have a page push ad on mobile
## Onion

prod link: http://www.theonion.com/article/man-wakes-coma-ability-understand-health-insurance-54099
test link: http://mobile-page-push.test.theonion.com/article/man-wakes-coma-ability-understand-health-insurance-54099
## Clickhole

prod link: http://www.clickhole.com/article/major-disaster-did-mike-pence-just-blow-debate-whe-4979
test link: http://mobile-page-push.test.clickhole.com/article/major-disaster-did-mike-pence-just-blow-debate-whe-4979
## Avclub

prod link: http://www.avclub.com/article/you-know-girls-case-file-71-strange-magic-243364
test link:  http://mobile-page-push.test.avclub.com/article/you-know-girls-case-file-71-strange-magic-243364
