### PR TITLE
add custom events to track dfp lifecylce

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: node_js
+node_js:
+- '5.1'
+- '5.9'
+sudo: false
+before_script:
+- bower install
+- npm install
+script:
+- npm test
+cache:
+  directories:
+  - node_modules
+  - bower_components

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ node_js:
 - '5.1'
 - '5.9'
 sudo: false
+before_install:
+- export CHROME_BIN=chromium-browser
+- export DISPLAY=:99.0
+- sh -e /etc/init.d/xvfb start
 before_script:
 - bower install
 - npm install

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ To run tests:
 $ npm test
 ```
 
+Tests will run on travis-ci as part of the pull request process.
+
 ### Notes
 #### Dependencies
 This project should never have outside, frontend dependencies since it really should be one of, if not, _the_ first JS to run on the page. Otherwise, potential ad views could be lost.

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -59,6 +59,13 @@ module.exports = function (config) {
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
     browsers: ['Chrome'],
 
+    customLaunchers: {
+      Chrome_travis_ci: {
+        base: 'Chrome',
+        flags: ['--no-sandbox']
+      }
+    },
+
     // Continuous Integration mode
     // if true, Karma captures browsers, runs the tests and exits
     singleRun: false,
@@ -77,5 +84,6 @@ module.exports = function (config) {
     config.captureTimeout = 0;
     config.singleRun = true;
     config.autoWatch = false;
+    config.browsers = ['Chrome_travis_ci'];
   }
 };

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "devDependencies": {
     "browserify": "^11.0.1",
+    "bower": "^1.7.9",
     "chai": "^3.2.0",
     "eslint": "^1.2.1",
     "jquery": "^2.2.1",

--- a/src/manager.js
+++ b/src/manager.js
@@ -45,6 +45,8 @@ AdManager.prototype.bindContext = function() {
   this.handleWindowResize = this.handleWindowResize.bind(this);
   this.loadAds = this.loadAds.bind(this);
   this.onSlotRenderEnded = this.onSlotRenderEnded.bind(this);
+  this.onImpressionViewable = this.onImpressionViewable.bind(this);
+  this.onSlotOnload = this.onSlotOnload.bind(this);
 };
 
 /**
@@ -79,6 +81,8 @@ AdManager.prototype.initGoogleTag = function() {
   this.googletag.pubads().collapseEmptyDivs(true);
 
   this.googletag.pubads().addEventListener('slotRenderEnded', adManager.onSlotRenderEnded);
+  this.googletag.pubads().addEventListener('impressionViewable', adManager.onImpressionViewable);
+  this.googletag.pubads().addEventListener('slotOnload', adManager.onSlotOnload);
 
   this.initBaseTargeting();
 
@@ -137,6 +141,31 @@ AdManager.prototype.onSlotRenderEnded = function(event) {
   }
 
   element.setAttribute('data-ad-load-state', 'loaded');
+  utils.dispatchEvent(element, 'dfpSlotRenderEnded');
+};
+
+/**
+ * Custom callback to wrap ad slot with additional functionality
+ *
+ * @param {Event} event - Event passed through the GPT library
+ * @returns undefined
+*/
+AdManager.prototype.onImpressionViewable = function(event) {
+  var slotId = event.slot.getSlotId().getDomId();
+  var element = document.getElementById(slotId);
+  utils.dispatchEvent(element, 'dfpImpressionViewable');
+};
+
+/**
+ * Custom callback to wrap ad slot with additional functionality
+ *
+ * @param {Event} event - Event passed through the GPT library
+ * @returns undefined
+*/
+AdManager.prototype.onSlotOnload = function(event) {
+  var slotId = event.slot.getSlotId().getDomId();
+  var element = document.getElementById(slotId);
+  utils.dispatchEvent(element, 'dfpSlotOnload');
 };
 
 /**

--- a/src/manager.spec.js
+++ b/src/manager.spec.js
@@ -117,6 +117,14 @@ describe('AdManager', function() {
       expect(adManager.googletag.pubads().addEventListener.calledWith('slotRenderEnded', adManager.onSlotRenderEnded)).to.be.true;
     });
 
+    it('sets up custom slot onImpressionViewable callback', function() {
+      expect(adManager.googletag.pubads().addEventListener.calledWith('impressionViewable', adManager.onImpressionViewable)).to.be.true;
+    });
+
+    it('sets up custom slot onload callback', function() {
+      expect(adManager.googletag.pubads().addEventListener.calledWith('slotOnload', adManager.onSlotOnload)).to.be.true;
+    });
+
     it('sets the global targeting on the pub ads service', function() {
       expect(adManager.initBaseTargeting.called).to.be.true;
     });
@@ -171,8 +179,9 @@ describe('AdManager', function() {
     });
   });
 
+
   describe('#onSlotRenderEnded', function() {
-    var adElement, event;
+    var adElement, event, eventSpy;
 
     beforeEach(function() {
       adElement = document.createElement('div');
@@ -196,6 +205,8 @@ describe('AdManager', function() {
       };
       adManager.rendered = false;
       TestHelper.stub(adManager.adUnits.units.header, 'onSlotRenderEnded');
+      eventSpy = sinon.spy();
+      adElement.addEventListener('dfpSlotRenderEnded', eventSpy);
       adManager.onSlotRenderEnded(event);
     });
 
@@ -221,6 +232,86 @@ describe('AdManager', function() {
 
     it('sets loaded state to loaded', function() {
       expect($(adElement).data('ad-load-state')).to.equal('loaded');
+    });
+
+    it('emits a dfpSlotRenderEnded event', function() {
+      expect(eventSpy).to.have.been.called;
+    });
+  });
+
+  describe('#onImpressionViewable', function()  {
+    var adElement, event, eventSpy;
+
+    beforeEach(function() {
+      adElement = document.createElement('div');
+      adElement.id = 'dfp-ad-1';
+      $(adElement).attr('style', 'height: 250px; width: 300px');
+      $(adElement).attr('data-ad-unit', 'header');
+      document.body.appendChild(adElement);
+      var getDomId = function() {
+        return 'dfp-ad-1';
+      };
+      var getSlotId = function() {
+        return {
+          getDomId: getDomId
+        }
+      };
+
+      event = {
+        slot: {
+          getSlotId: getSlotId
+        }
+      };
+      TestHelper.stub(adManager.adUnits.units.header, 'onSlotRenderEnded');
+      eventSpy = sinon.spy();
+      adElement.addEventListener('dfpImpressionViewable', eventSpy);
+      adManager.onSlotRenderEnded(event);
+    });
+
+    afterEach(function() {
+      $(adElement).remove();
+    });
+
+    it('emits a dfpImpressionViewable event', function() {
+      expect(eventSpy).to.have.been.called;
+    });
+  });
+
+  describe('#onSlotOnload', function() {
+    var adElement, event, eventSpy;
+
+    beforeEach(function() {
+      adElement = document.createElement('div');
+      adElement.id = 'dfp-ad-1';
+      $(adElement).attr('style', 'height: 250px; width: 300px');
+      $(adElement).attr('data-ad-unit', 'header');
+      document.body.appendChild(adElement);
+      var getDomId = function() {
+        return 'dfp-ad-1';
+      };
+      var getSlotId = function() {
+        return {
+          getDomId: getDomId
+        }
+      };
+
+      event = {
+        slot: {
+          getSlotId: getSlotId
+        }
+      };
+      TestHelper.stub(adManager.adUnits.units.header, 'onSlotRenderEnded');
+      eventSpy = sinon.spy();
+      adElement.addEventListener('dfpSlotOnload', eventSpy);
+      adManager.onSlotRenderEnded(event);
+    });
+
+    afterEach(function() {
+      $(adElement).remove();
+    });
+
+    it('emits a dfpSlotOnload event', function() {
+      expect(eventSpy).to.have.been.called;
     });
   });
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -74,6 +74,21 @@ var Utils = {
     var innerHeight    = window.innerHeight || window.document.documentElement.clientHeight;
 
     return rect.top <= innerHeight + withinDistance && rect.top >= -withinDistance;
+  },
+
+  dispatchEvent: function (el, eventName) {
+    var customEvent;
+    try {
+      customEvent = new window.CustomEvent(eventName, {
+        bubbles: true,
+        cancelable: true
+      });
+    }
+    catch (e) {
+      customEvent = document.createEvent('Event');
+      customEvent.initEvent(eventName, true, true);
+    }
+    el.dispatchEvent(customEvent);
   }
 };
 

--- a/src/utils.spec.js
+++ b/src/utils.spec.js
@@ -55,4 +55,12 @@ describe('Utils', function () {
     expect(utils.elementNearViewport(element, { withinDistance: 100})).to.equal(false);
     expect(utils.elementNearViewport(element, { withinDistance: 201})).to.equal(true);
   });
+
+  it('should emit custom events', function () {
+    var element = document.createElement('div');
+    var spy = sinon.spy();
+    element.addEventListener('coolEvent', spy);
+    utils.dispatchEvent(element, 'coolEvent');
+    expect(spy).to.have.been.called;
+  });
 });


### PR DESCRIPTION
@spra85 @kand @MelizzaP 

This adds some new event handling to our ad slots. 

```js
this.googletag.pubads().addEventListener('slotRenderEnded', adManager.onSlotRenderEnded);
this.googletag.pubads().addEventListener('impressionViewable', adManager.onImpressionViewable);
this.googletag.pubads().addEventListener('slotOnload', adManager.onSlotOnload)
```

(`slotRenderEnded` was already being handled before this PR.)

Of particular interest are the new DOM custom events that we emit on the slot element as dfp goes through its lifecycle:

```js
 utils.dispatchEvent(element, 'dfpSlotRenderEnded');
/***/
 utils.dispatchEvent(element, 'dfpImpressionViewable');
/***/
 utils.dispatchEvent(element, 'dfpSlotOnload');
```

At the present we will be handling these events in `<div is="bulbs-dfp">` to send more analytics events around our ad rendering.