### PR TITLE
prevent header slot refresh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+*.swp
+
 bower_components
 node_modules
 

--- a/src/ad-units.js
+++ b/src/ad-units.js
@@ -138,6 +138,7 @@ AdUnits.units = {
   },
 
   'header': {
+    'refreshDisabled': true,
     'slotName': 'header',
     'sizes': [
       [[970, 0], [[728, 90], [1,1], [970, 415], [970, 250], [970, 90]]],


### PR DESCRIPTION
Prevent header slot from automatically refreshing. Will be released in conjunction with theonion/bulbs-elements#181.

**Release Type**: _patch_
No large-scale features, no breaking changes.

**Updates**

1. `header` slot has `refreshDisabled` to prevent it refreshing automatically.