### PR TITLE
Changes to allow for lazy-loading ads

### DIFF
--- a/src/ad-units.js
+++ b/src/ad-units.js
@@ -139,6 +139,7 @@ AdUnits.units = {
 
   'header': {
     'refreshDisabled': true,
+    'eagerLoad': true,
     'slotName': 'header',
     'sizes': [
       [[970, 0], [[728, 90], [1,1], [970, 415], [970, 250], [970, 90]]],

--- a/src/ad-units.js
+++ b/src/ad-units.js
@@ -132,6 +132,7 @@ var AdUnits = {
 
 AdUnits.units = {
   'campaign-pixel': {
+    'eagerLoad': true,
     'sizes': [
       [[0, 0], [1, 1]]
     ]

--- a/src/manager.js
+++ b/src/manager.js
@@ -414,7 +414,7 @@ AdManager.prototype.refreshSlots = function (slotsToLoad, ads) {
   if (typeof window.index_headertag_lightspeed === 'undefined') {
     this.googletag.pubads().refresh(slotsToLoad, { changeCorrelator: false });
   } else {
-    window.index_headertag_lightspeed.slotRefresh(slotsToLoad, ads);
+    window.index_headertag_lightspeed.slotRefresh(slotsToLoad, ads, { changeCorrelator: false });
   }
 };
 


### PR DESCRIPTION
Note - This is a breaking change, which will result in a major version bump to 3.x.  This changes the `loadAds` implementation to defer the call to refresh the slot (which actually fetches the new ad) to the bulbs-elements custom bulbs-dfp element when it is about to come into view unless the ad is configured to `eagerLoad`.  These changes need to be paired with the implementation in this bulbs-elements PR (https://github.com/theonion/bulbs-elements/pull/198).  

Test link below:
http://lazy-load-ads.test.clickhole.com