### PR TITLE
Must eager load this because Facebook already lazy loads

### DIFF
--- a/src/ad-units.js
+++ b/src/ad-units.js
@@ -239,6 +239,7 @@ AdUnits.units = {
   },
 
   'instant-article-inread': {
+    'eagerLoad': true,
     'slotName': 'instant-article-inread',
     'sizes': [
       [[0,0], [300,250]]


### PR DESCRIPTION
...  and you are unable to listen to the scroll event with iframes inside Facebook instant