### PR TITLE
Improvements to ad loading consistency

### DIFF
--- a/src/manager.js
+++ b/src/manager.js
@@ -412,9 +412,9 @@ AdManager.prototype.refreshSlots = function (slotsToLoad, ads) {
   }
 
   if (typeof window.index_headertag_lightspeed === 'undefined') {
-    this.googletag.pubads().refresh(slotsToLoad, { changeCorrelator: false });
+    this.googletag.pubads().refresh(slotsToLoad);
   } else {
-    window.index_headertag_lightspeed.slotRefresh(slotsToLoad, ads, { changeCorrelator: false });
+    window.index_headertag_lightspeed.slotRefresh(slotsToLoad, ads);
   }
 };
 

--- a/src/manager.js
+++ b/src/manager.js
@@ -76,6 +76,8 @@ AdManager.prototype.initGoogleTag = function() {
   var adManager = this;
 
   this.googletag.pubads().disableInitialLoad();
+  this.googletag.pubads().enableAsyncRendering();
+  this.googletag.pubads().updateCorrelator();
 
   this.googletag.pubads().addEventListener('slotRenderEnded', adManager.onSlotRenderEnded);
   this.googletag.pubads().addEventListener('impressionViewable', adManager.onImpressionViewable);
@@ -115,6 +117,7 @@ AdManager.prototype.initBaseTargeting = function() {
  * @returns undefined
 */
 AdManager.prototype.reloadAds = function(element) {
+  this.googletag.pubads().updateCorrelator();
   this.unloadAds(element);
   this.loadAds(element);
 };
@@ -377,9 +380,9 @@ AdManager.prototype.loadAds = function(element) {
     } else {
       window.index_headertag_lightspeed.slotDisplay(thisEl.id, ads);
     }
-    thisEl.setAttribute('data-ad-load-state', 'loading');
 
     if (slot.eagerLoad) {
+      thisEl.setAttribute('data-ad-load-state', 'loading');
       this.refreshSlots([slot], ads);
     }
   }
@@ -392,10 +395,15 @@ AdManager.prototype.loadAds = function(element) {
  * @returns undefined
 */
 AdManager.prototype.refreshSlot = function(domElement) {
+  if ((domElement.getAttribute('data-ad-load-state') === 'loaded') || (domElement.getAttribute('data-ad-load-state') === 'loading')) {
+    return;
+  }
+
   var slot = this.slots[domElement.id];
   var ads = this.findAds(domElement);
 
   if (slot) {
+    domElement.setAttribute('data-ad-load-state', 'loading');
     this.refreshSlots([slot], ads);
   }
 };
@@ -412,9 +420,9 @@ AdManager.prototype.refreshSlots = function (slotsToLoad, ads) {
   }
 
   if (typeof window.index_headertag_lightspeed === 'undefined') {
-    this.googletag.pubads().refresh(slotsToLoad);
+    this.googletag.pubads().refresh(slotsToLoad, { changeCorrelator: false });
   } else {
-    window.index_headertag_lightspeed.slotRefresh(slotsToLoad, ads);
+    window.index_headertag_lightspeed.slotRefresh(slotsToLoad, ads, { changeCorrelator: false });
   }
 };
 


### PR DESCRIPTION
This PR does a few things, namely: 

- Prevents the bulbs-dfp custom element from refreshing an ad slot based on viewport detection when the slot is already in the process of loading from the ad server
- Makes sure that any time a new ads manager is instantiated the correlator on the page is updated
- Makes sure any time ads are triggered to reload on the page, a new correlator is updated as well

This will be a patch release for the current version

Test link: 
http://change-correlator.test.theonion.com/