### PR TITLE
empty slot fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.swp
+.s*
 
 bower_components
 node_modules

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bulbs-public-ads-manager",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "Do not install via npm.",
   "private": false,
   "scripts": {

--- a/src/manager.js
+++ b/src/manager.js
@@ -137,12 +137,17 @@ AdManager.prototype.onSlotRenderEnded = function(event) {
   element.style.removeProperty('height');
   element.style.removeProperty('width');
 
-  if (adUnits.units[element.dataset.adUnit].onSlotRenderEnded) {
-    adUnits.units[element.dataset.adUnit].onSlotRenderEnded(event, element);
-  }
+  if (event.isEmpty) {
+    element.setAttribute('data-ad-load-state', 'empty');
+  } else {
 
-  element.setAttribute('data-ad-load-state', 'loaded');
-  utils.dispatchEvent(element, 'dfpSlotRenderEnded');
+    if (adUnits.units[element.dataset.adUnit].onSlotRenderEnded) {
+      adUnits.units[element.dataset.adUnit].onSlotRenderEnded(event, element);
+    }
+
+    element.setAttribute('data-ad-load-state', 'loaded');
+    utils.dispatchEvent(element, 'dfpSlotRenderEnded');
+  }
 };
 
 /**

--- a/src/manager.spec.js
+++ b/src/manager.spec.js
@@ -231,7 +231,6 @@ describe('AdManager', function() {
       TestHelper.stub(adManager.adUnits.units.header, 'onSlotRenderEnded');
       eventSpy = sinon.spy();
       adElement.addEventListener('dfpSlotRenderEnded', eventSpy);
-      adManager.onSlotRenderEnded(event);
     });
 
     afterEach(function() {
@@ -239,27 +238,55 @@ describe('AdManager', function() {
     });
 
     it('sets rendered to true', function() {
+
+      adManager.onSlotRenderEnded(event);
+
       expect(adManager.rendered).to.be.true;
     });
 
     it('removes the height property', function() {
+
+      adManager.onSlotRenderEnded(event);
+
       expect(adElement.style.height).not.to.equal('250px');
     });
 
     it('removes the width property', function() {
+
+      adManager.onSlotRenderEnded(event);
+
       expect(adElement.style.width).not.to.equal('300px');
     });
 
     it('calls custom slot render ended callback if there is one', function() {
+
+      adManager.onSlotRenderEnded(event);
+
       expect(adManager.adUnits.units.header.onSlotRenderEnded.calledWith(event, adElement)).to.be.true;
     });
 
     it('sets loaded state to loaded', function() {
+
+      adManager.onSlotRenderEnded(event);
+
       expect($(adElement).data('ad-load-state')).to.equal('loaded');
     });
 
     it('emits a dfpSlotRenderEnded event', function() {
-      expect(eventSpy).to.have.been.called;
+
+      adManager.onSlotRenderEnded(event);
+
+      expect(eventSpy.called).to.be.true;
+    });
+
+    it('does not dispatch slot render end, does not call callback when ad comes back empty', function() {
+      event.isEmpty = true;
+
+      adManager.onSlotRenderEnded(event);
+
+      expect($(adElement).data('ad-load-state')).to.equal('empty');
+      expect(adManager.adUnits.units.header.onSlotRenderEnded.called).to.be.false;
+      expect(eventSpy.called).to.be.false;
     });
   });
 


### PR DESCRIPTION
Don't call render end callbacks and events when ad is empty.

**Release type**: _patch_
No major changes, only a fix.