### PR TITLE
Adds a state to the parent wrapper reflective of whether the ad has loaded

### DIFF
--- a/src/ad-units.js
+++ b/src/ad-units.js
@@ -131,6 +131,7 @@ var AdUnits = {
 
   headerSlotRenderEnded: function(e, el) {
     var parent = el.parentElement;
+    parent.setAttribute('data-ad-load-state', 'loaded');
     AdUnits.resetClasses(parent);
 
     if (e.size[0] === 320) {

--- a/src/ad-units.spec.js
+++ b/src/ad-units.spec.js
@@ -458,6 +458,11 @@ describe('Ad Units', function() {
       adUnits.headerSlotRenderEnded(e, adElement);
       expect(adUnits.handleSuperHeroHeaderSlot.calledWith(e, adElement)).to.be.true;
     });
+
+    it('adds the data-ad-load-state to the parent wrapper as well', function() {
+      adUnits.headerSlotRenderEnded({ size: [320, 50]}, adElement);
+      expect($(parentAdElement).data('ad-load-state')).to.equal('loaded');
+    });
   });
 
   describe('header slot config', function() {


### PR DESCRIPTION
@jmelvnsn, this should be what you can key off to remove the margin, background, etc. from the header wrapper until the ad has been loaded

Also, looking for additional approvals @kand @collin @shawncook @MelizzaP 