### PR TITLE
Update correlator option

### DIFF
--- a/src/manager.js
+++ b/src/manager.js
@@ -367,7 +367,7 @@ AdManager.prototype.unpause = function() {
  * @param {Element} optional element to scope where to load ads in the document
  * @returns undefined
 */
-AdManager.prototype.loadAds = function(element) {
+AdManager.prototype.loadAds = function(element, updateCorrelator) {
   if (this.paused || !this.initialized) {
     return;
   }
@@ -377,6 +377,10 @@ AdManager.prototype.loadAds = function(element) {
 
   if (!this.googletag.pubadsReady) {
     this.googletag.enableServices();
+  }
+
+  if (updateCorrelator) {
+    this.googletag.pubads().updateCorrelator();
   }
 
   for(var i = 0; i < ads.length; i++) {

--- a/src/manager.js
+++ b/src/manager.js
@@ -365,6 +365,7 @@ AdManager.prototype.unpause = function() {
  * Loads all ads
  *
  * @param {Element} optional element to scope where to load ads in the document
+ * @param {updateCorrelator} optional flag to force an update of the correlator value
  * @returns undefined
 */
 AdManager.prototype.loadAds = function(element, updateCorrelator) {

--- a/src/manager.spec.js
+++ b/src/manager.spec.js
@@ -704,6 +704,7 @@ describe('AdManager', function() {
         enableSingleRequest: sinon.spy(),
         disableInitialLoad: sinon.spy(),
         addEventListener: sinon.spy(),
+        updateCorrelator: sinon.spy(),
         refresh: sinon.spy(),
         clear: sinon.spy(),
         setTargeting: sinon.spy()
@@ -867,6 +868,16 @@ describe('AdManager', function() {
 
       it('does not try to refresh pubads across the board', function() {
         expect(adManager.googletag.pubads().refresh.called).to.be.false;
+      });
+    });
+
+    context('update correlator true', function() {
+      beforeEach(function() {
+        adManager.loadAds(undefined, true);
+      });
+
+      it('updates the correlator', function() {
+        expect(adManager.googletag.pubads().updateCorrelator.called).to.be.true;
       });
     });
 


### PR DESCRIPTION
This PR provides an optional flag allowing an integrating site, etc. to force an update of the correlator prior to loading ads