### PR TITLE
Refactor to remove dependencies on utils

### DIFF
--- a/src/ad-units.js
+++ b/src/ad-units.js
@@ -1,16 +1,14 @@
 'use strict';
 
-var utils = require('./utils');
-
 var AdUnits = {
   toggleDelay: 6000,
 
   resetClasses: function(parent) {
-    utils.removeClass(parent, 'pinned');
-    utils.removeClass(parent, 'mobile');
-    utils.removeClass(parent, 'kargo');
-    utils.removeClass(parent, 'page-push');
-    utils.removeClass(parent, 'super-hero');
+    parent.classList.remove('pinned');
+    parent.classList.remove('mobile');
+    parent.classList.remove('kargo');
+    parent.classList.remove('page-push');
+    parent.classList.remove('super-hero');
     parent.style.height = '';
   },
 
@@ -18,9 +16,9 @@ var AdUnits = {
     var toggleButton = document.createElement('div');
     toggleButton.className = 'toggle-btn open';
     this.delayAdToggle(adElement, toggleButton);
-    utils.addClass(adElement.parentElement, 'pinned');
-    utils.addClass(adElement.parentElement, 'open');
-    utils.addClass(adElement.parentElement, 'hide-toggle-btn');
+    adElement.parentElement.classList.add('pinned');
+    adElement.parentElement.classList.add('open');
+    adElement.parentElement.classList.add('hide-toggle-btn');
     adElement.parentElement.appendChild(toggleButton);
   },
 
@@ -37,16 +35,17 @@ var AdUnits = {
     var closedClass = 'closed';
     var toggleButton = adElement.nextElementSibling;
 
-    if (utils.hasClass(toggleButton, 'open')) {
-      utils.removeClass(toggleButton, openedClass);
-      utils.removeClass(adElement.parentElement, openedClass);
-      utils.addClass(toggleButton, closedClass);
-      utils.addClass(adElement.parentElement, closedClass);
+    if (toggleButton.classList.contains('open')) {
+      toggleButton.classList.remove(openedClass);
+      adElement.parentElement.classList.remove(openedClass);
+      toggleButton.classList.add(closedClass);
+      adElement.parentElement.classList.add(closedClass);
     } else {
-      utils.removeClass(toggleButton, closedClass);
-      utils.removeClass(adElement.parentElement, closedClass);
-      utils.addClass(toggleButton, openedClass);
-      utils.addClass(adElement.parentElement, openedClass);
+      toggleButton.classList.remove(closedClass);
+      adElement.parentElement.classList.remove(closedClass);
+
+      toggleButton.classList.add(openedClass);
+      adElement.parentElement.classList.add(openedClass);
     }
   },
 
@@ -54,33 +53,20 @@ var AdUnits = {
     setTimeout(function() {
       AdUnits.toggleAd(adElement);
       AdUnits.initToggleHandler(adElement, toggleButton);
-      utils.removeClass(adElement.parentElement, 'hide-toggle-btn');
+      adElement.parentElement.classList.remove('hide-toggle-btn');
     }, this.toggleDelay);
-  },
-
-  isKargo: function(e) {
-    var re = new RegExp(/kargo/);
-    var slot = e.slot.L;
-    if (re.test(slot) || e.lineItemId === 356279568 || e.lineItemId === 336705048) {
-      return true;
-    } else {
-      return false;
-    }
   },
 
   setupMobileSlotClasses: function(e, el) {
     var parent = el.parentElement;
-    utils.addClass(parent, 'mobile');
-
-    if (AdUnits.isKargo(e)) {
-      utils.addClass(parent, 'kargo');
-    }
+    parent.classList.add('mobile');
   },
 
   handleMobileHeaderSlot: function(e, el) {
     var parent = el.parentElement;
     AdUnits.makeAdTogglable(el);
-    if (!utils.hasClass(parent, 'header-wrapper')) {
+
+    if (!parent.classList.contains('header-wrapper')) {
       return;
     }
 
@@ -92,13 +78,13 @@ var AdUnits = {
   },
 
   handlePagePushHeaderSlot: function(e, el) {
-    utils.addClass(el.parentElement, 'page-push');
+    el.parentElement.classList.add('page-push');
 
     var dfpContainer = document.getElementById(e.slot.getSlotElementId());
     var adIframe = dfpContainer.getElementsByTagName('iframe');
     var iframe = adIframe[0];
     var iframeDoc = iframe.contentDocument || iframe.contentWindow.document;
-    utils.removeClass(dfpContainer, 'collapsed');
+    dfpContainer.classList.remove('collapsed');
 
     if (iframeDoc.readyState === 'complete') {
       AdUnits.prepPagePushIframe(dfpContainer, iframe);
@@ -108,7 +94,7 @@ var AdUnits = {
   },
 
   handleSuperHeroHeaderSlot: function(e, el) {
-    utils.addClass(el.parentElement, 'super-hero');
+    el.parentElement.classList.add('super-hero');
 
     var height = document.documentElement.clientHeight - 175;
     if (height > 720) {
@@ -121,11 +107,11 @@ var AdUnits = {
     var iframeDoc = iframe.contentDocument || iframe.contentWindow.document;
 
     iframeDoc.addEventListener('PagePush:Expand', function() {
-      utils.removeClass(dfpContainer, 'collapsed');
+      dfpContainer.classList.remove('collapsed');
     });
 
     iframeDoc.addEventListener('PagePush:Collapse', function () {
-      utils.addClass(dfpContainer, 'collapsed');
+      dfpContainer.classList.add('collapsed');
     });
   },
 

--- a/src/ad-units.spec.js
+++ b/src/ad-units.spec.js
@@ -198,36 +198,6 @@ describe('Ad Units', function() {
         expect($(parentAdElement).hasClass('mobile')).to.be.true;
       });
     });
-
-    describe('kargo unit', function() {
-      beforeEach(function() {
-        var e = {
-          slot: {
-            L: 'something-kargo-something'
-          }
-        };
-        adUnits.setupMobileSlotClasses(e, adElement);
-      });
-
-      it('adds `kargo` class to the parent', function() {
-        expect($(parentAdElement).hasClass('kargo')).to.be.true;
-      });
-    });
-
-    describe('non-kargo unit', function() {
-      beforeEach(function() {
-        var e = {
-          slot: {
-            L: ''
-          }
-        };
-        adUnits.setupMobileSlotClasses(e, parentAdElement);
-      });
-
-      it('does not add kargo class', function() {
-        expect($(parentAdElement).hasClass('kargo')).to.be.false;
-      });
-    });
   });
 
   describe('#handleMobileHeaderSlot', function() {

--- a/src/manager.js
+++ b/src/manager.js
@@ -211,7 +211,7 @@ AdManager.prototype.generateId = function() {
  * @returns true if it has the 'dfp' class, false otherwise
 */
 AdManager.prototype.isAd = function (element) {
-  return !!utils.hasClass(element, 'dfp');
+  return !!element.classList.contains('dfp');
 };
 
 /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -26,56 +26,6 @@ var Utils = {
     return out;
   },
 
-  /**
-   * Test if given element has a given class.
-   *
-   * @param {Element} el - element to test.
-   * @param {string} className - class name to test for.
-   * @returns true if element has given class, false otherwise.
-   */
-  hasClass: function (el, className) {
-    return el.className && !!el.className.match('(^|\\s)' + className + '($|\\s)');
-  },
-
-  /**
-   * Remove a given class from given element.
-   *
-   * @param {Element} el - element to remove class from.
-   * @param {string} className - class to remove.
-   */
-  removeClass: function (el, className) {
-    el.className = el.className.replace(new RegExp('(^|\\s)' + className + '($|\\s)', 'g'), ' ');
-  },
-
-  /**
-   * Add a given class to given element.
-   *
-   * @param {Element} el - element to add class to.
-   * @param {string} className - class name to add.
-   */
-  addClass: function (el, className) {
-    if (!Utils.hasClass(el, className)) {
-      el.className += ' ' + className;
-    }
-  },
-
-  /**
-   * Check if element is inside visible viewport, within a specific distance.
-   *
-   * @param {Element} el - element to check.
-   * @param {object} options - {withinDistance: {integer}} number of pixels to check.
-   */
-  elementNearViewport: function (el, options) {
-    if (!options) {
-      options = {};
-    }
-    var withinDistance = options.withinDistance || 0;
-    var rect           = el.getBoundingClientRect();
-    var innerHeight    = window.innerHeight || window.document.documentElement.clientHeight;
-
-    return rect.top <= innerHeight + withinDistance && rect.top >= -withinDistance;
-  },
-
   dispatchEvent: function (el, eventName) {
     var customEvent;
     try {

--- a/src/utils.spec.js
+++ b/src/utils.spec.js
@@ -10,52 +10,6 @@ describe('Utils', function () {
     document.body.appendChild(element);
   });
 
-  it('should have a function to check if an element has a class', function () {
-    element.className = 'something dfp-ad';
-
-    expect(utils.hasClass(element, 'something')).to.equal(true);
-    expect(utils.hasClass(element, 'dfp')).to.equal(false);
-  });
-
-  it('should have a function to remove a class frome an element', function () {
-    element.className = 'onetwothree one two three';
-
-    utils.removeClass(element, 'two');
-
-    expect(element.className).to.equal('onetwothree one three');
-  });
-
-  it('should have a function to add a class to an element', function () {
-    element.className = 'dfp ads';
-
-    utils.addClass(element, 'yay');
-
-    expect(element.className).to.equal('dfp ads yay');
-  });
-
-  it('should be able to tell if an element is close to the viewport', function () {
-    var innerHeight = window.innerHeight;
-
-    element.style.position = 'absolute';
-    element.style.top = innerHeight + 'px';
-
-    expect(utils.elementNearViewport(element, { withinDistance: 0 })).to.equal(true);
-
-    element.style.top = innerHeight + 1 + 'px';
-
-    expect(utils.elementNearViewport(element, { withinDistance: 0 })).to.equal(false);
-
-    element.style.top = innerHeight + 100 + 'px';
-
-    expect(utils.elementNearViewport(element, { withinDistance: 0})).to.equal(false);
-    expect(utils.elementNearViewport(element, { withinDistance: 100 })).to.equal(true);
-
-    element.style.top = '-200px';
-
-    expect(utils.elementNearViewport(element, { withinDistance: 100})).to.equal(false);
-    expect(utils.elementNearViewport(element, { withinDistance: 201})).to.equal(true);
-  });
-
   it('should emit custom events', function () {
     var element = document.createElement('div');
     var spy = sinon.spy();


### PR DESCRIPTION
Primary reason for this PR is to remove the dependency on `utils.js` for the `ad-units.js` file, which will allow us to remove that ad-units.js altogether from this repo.

Removes need for hasClass, removeClass, addClass in favor of native classList.

`classList` works natively on all browsers, with a few exceptions for IE11 (of course): http://caniuse.com/#search=classList

Notes on using: https://developer.mozilla.org/en-US/docs/Web/API/Element/classList

Namely, it will not work on IE11 on SVG elements (not applicable for us) and `add` and `remove` will not support multiple parameters on IE11.  This why a few cases in this PR are multi-lined for those instances.