### PR TITLE
When async refresh is called, update the correlator

### DIFF
--- a/src/manager.js
+++ b/src/manager.js
@@ -478,9 +478,11 @@ AdManager.prototype.asyncRefreshSlot = function(domElement) {
   var adManager = this;
 
   if (this.googletag.apiReady) {
+    this.googletag.pubads().updateCorrelator();
     this.refreshSlot(domElement);
   } else {
     this.googletag.cmd.push(function () {
+      adManager.googletag.pubads().updateCorrelator();
       adManager.refreshSlot(domElement);
     });
   }

--- a/src/manager.spec.js
+++ b/src/manager.spec.js
@@ -1144,6 +1144,9 @@ describe('AdManager', function() {
 
     beforeEach(function() {
       TestHelper.stub(adManager, 'refreshSlot');
+      TestHelper.stub(adManager.googletag, 'pubads').returns({
+        updateCorrelator: sinon.spy(),
+      });
 
       baseContainer = document.createElement('div');
       container1 = document.createElement('div');
@@ -1171,6 +1174,10 @@ describe('AdManager', function() {
       it('refreshes the slot right away', function() {
         expect(adManager.refreshSlot.calledWith(adSlot1)).to.be.true;
       });
+
+      it('updates the correlator', function() {
+        expect(adManager.googletag.pubads().updateCorrelator.called).to.be.true;
+      });
     });
 
     context('api is not ready', function() {
@@ -1189,6 +1196,10 @@ describe('AdManager', function() {
 
       it('refreshes the slot by way of the `cmd` async queue', function () {
         expect(adManager.refreshSlot.calledWith(adSlot1)).to.be.true;
+      });
+
+      it('updates the correlator', function() {
+        expect(adManager.googletag.pubads().updateCorrelator.called).to.be.true;
       });
     });
   });


### PR DESCRIPTION
Test links provided in Omni PR (https://github.com/theonion/omni/pull/1241)