### PR TITLE
SRA for bulbs

### DIFF
--- a/src/manager.js
+++ b/src/manager.js
@@ -431,7 +431,7 @@ AdManager.prototype.loadAds = function(element, updateCorrelator) {
 
     var slot = this.configureAd(thisEl);
 
-    if (slot) {
+    if (slot && slot.eagerLoad) {
       slotsToLoad.push(slot);
     }
 
@@ -441,13 +441,15 @@ AdManager.prototype.loadAds = function(element, updateCorrelator) {
       window.headertag.display(thisEl.id);
     }
 
-     // If SRA and its the final ad in the queue
-     if (ads.length === i + 1 && slot.eagerLoad && this.options.enableSRA) {
-       this.refreshSlots(slotsToLoad);
-     } else if (slot.eagerLoad && !this.options.enableSRA) {
-       this.refreshSlot(thisEl);
-     }
+    if (slot.eagerLoad && !this.options.enableSRA) {
+      this.refreshSlot(thisEl);
+    }
   }
+
+  if (slotsToLoad.length && this.options.enableSRA) {
+    this.refreshSlots(slotsToLoad);
+  }
+
 };
 
 /**

--- a/src/manager.js
+++ b/src/manager.js
@@ -13,7 +13,8 @@ var AdManager = function(options) {
     resizeTimeout: null,
     debug: false,
     dfpId: 4246,
-    amazonEnabled: true,
+    amazonEnabled: false,
+	enableSRA: false
   };
   var options = options || {};
 
@@ -84,6 +85,10 @@ AdManager.prototype.initGoogleTag = function() {
   this.googletag.pubads().disableInitialLoad();
   this.googletag.pubads().enableAsyncRendering();
   this.googletag.pubads().updateCorrelator();
+  
+  if (this.options.enableSRA) {
+    this.googletag.pubads().enableSingleRequest();
+  }
 
   this.googletag.pubads().addEventListener('slotRenderEnded', adManager.onSlotRenderEnded);
   this.googletag.pubads().addEventListener('impressionViewable', adManager.onImpressionViewable);
@@ -436,9 +441,12 @@ AdManager.prototype.loadAds = function(element, updateCorrelator) {
       window.headertag.display(thisEl.id);
     }
 
-    if (slot.eagerLoad) {
-      this.refreshSlot(thisEl);
-    }
+     // If SRA and its the final ad in the queue
+     if (ads.length === i + 1 && slot.eagerLoad && this.options.enableSRA) {
+       this.refreshSlot(slotsToLoad);
+     } else if (slot.eagerLoad) {
+       this.refreshSlot(thisEl);
+     }
   }
 };
 

--- a/src/manager.js
+++ b/src/manager.js
@@ -552,7 +552,6 @@ AdManager.prototype.refreshSlots = function(slotsToLoad) {
       changeCorrelator: false
     });
   } else {
-    window.headertag = window.googletag;
     window.headertag.pubads().refresh(slotsToLoad, {
       changeCorrelator: false
     });

--- a/src/manager.js
+++ b/src/manager.js
@@ -13,8 +13,8 @@ var AdManager = function(options) {
     resizeTimeout: null,
     debug: false,
     dfpId: 4246,
-    amazonEnabled: false,
-	enableSRA: false
+    amazonEnabled: true,
+    enableSRA: false
   };
   var options = options || {};
 
@@ -443,8 +443,8 @@ AdManager.prototype.loadAds = function(element, updateCorrelator) {
 
      // If SRA and its the final ad in the queue
      if (ads.length === i + 1 && slot.eagerLoad && this.options.enableSRA) {
-       this.refreshSlot(slotsToLoad);
-     } else if (slot.eagerLoad) {
+       this.refreshSlots(slotsToLoad);
+     } else if (slot.eagerLoad && !this.options.enableSRA) {
        this.refreshSlot(thisEl);
      }
   }
@@ -541,7 +541,7 @@ AdManager.prototype.refreshAds = function (domElement) {
  * @param {domElement} DOM element containing the DFP ad
  * @returns undefined
 */
-AdManager.prototype.refreshSlots = function(slotsToLoad, domElement) {
+AdManager.prototype.refreshSlots = function(slotsToLoad) {
 
   if (slotsToLoad.length === 0) {
     return;

--- a/src/manager.spec.js
+++ b/src/manager.spec.js
@@ -116,8 +116,11 @@ describe('AdManager', function() {
       adManager.initGoogleTag();
     });
 
-    it('does not enable single request mode', function() {
+    it('enable single request mode when option enabled, otherwise disable it', function() {
       expect(adManager.googletag.pubads().enableSingleRequest.called).to.be.false;
+      adManager.options.enableSRA = true;
+      adManager.initGoogleTag();
+      expect(adManager.googletag.pubads().enableSingleRequest.called).to.be.true;
     });
 
     it('disables initial load of ads, to defer to the eager/lazy loading logic', function() {


### PR DESCRIPTION
Enables Google Single request mode for The top banner, superhero (top&bottom), and welcome ad to be  requested at the same time. The result looks like the response below.
![screen shot 2017-09-13 at 5 42 53 pm](https://user-images.githubusercontent.com/860921/30402251-28db1226-98ab-11e7-8f31-c6328c23e690.png)

The corresponding PR to enable the functionality in kinja is here: 
https://github.com/gawkermedia/kinja-mantle/pull/12263

TODO: Due to the way this is designed, we'll need to check how the header bids are placed as key vals. Since they are added using setTargeting, the expectation is that DFP will wrap the keys within the individual ad calls.  However in the short term index is having issues appending key vals.  As such more validation will be required with index exchange.

see https://github.com/theonion/bulbs-public-ads-manager/pull/38