### PR TITLE
Amazon APSTag / A9 multislot for bulbs

### DIFF
--- a/src/helpers/TargetingPairs.js
+++ b/src/helpers/TargetingPairs.js
@@ -14,7 +14,7 @@ var TargetingPairs = {
    * @param Window scope the window to use for the kinja meta info.
    *
    */
-  buildTargetingPairs: function(scope) {
+  buildTargetingPairs: function(scope, position) {
     var kinjaMeta = scope.kinja.meta,
       post = scope.kinja.postMeta || {},
       content = scope.kinja.postContentRatings || [],
@@ -41,8 +41,8 @@ var TargetingPairs = {
       kuid: (scope.Krux && scope.Krux.user) ? scope.Krux.user : undefined
     };
 
-    if (experimentVariation !== null && experimentId !== null) {
-      targeting.pageOptions.exp_variation = experimentId + '_' + experimentVariation;
+    if (experimentVariation !== null && experimentId !== null && position) {
+      targeting.pageOptions.exp_variation = experimentId + '_' + experimentVariation + '_' + position;
     }
 
     return targeting;
@@ -55,12 +55,12 @@ var TargetingPairs = {
    * @param Window scope the window to use for the kinja meta info.
    *
    */
-  getTargetingPairs: function(forcedAdZone) {
+  getTargetingPairs: function(forcedAdZone, position) {
     if (!window.kinja) {
       return {};
     }
 
-    var targetingOptions = this.buildTargetingPairs(window);
+    var targetingOptions = this.buildTargetingPairs(window, position);
 
     targetingOptions.pageOptions.forcedAdZone = forcedAdZone || false;
 

--- a/src/manager.js
+++ b/src/manager.js
@@ -103,10 +103,10 @@ AdManager.prototype.initGoogleTag = function() {
  *
  * @returns undefined
 */
-AdManager.prototype.fetchAPSBids = function(element, gptSizes) {
+AdManager.prototype.fetchAmazonBids = function(elementId, gptSizes) {
 	window.apstag.fetchBids({
 		slots: [{
-			slotID: element,
+			slotID: elementId,
 			sizes: gptSizes
 		}],
 		timeout: 2e3
@@ -282,10 +282,10 @@ AdManager.prototype.generateId = function() {
 AdManager.prototype.adSizesMatchingViewport = function (gptSizes) {
   return gptSizes.filter(function(sizes) {
     var minWidth = sizes[0][0];
-    if (window.matchMedia('(min-width:' + minWidth + 'px)').matches) {
+    if (window.matchMedia('(min-width:' + minWidth + 'px)').matches && sizes[1].length) {
       return sizes[1];
     }
-  });
+  })[0];
 };
 
 /**
@@ -515,10 +515,9 @@ AdManager.prototype.loadAds = function(element, updateCorrelator) {
 	if (this.options.amazonEnabled) {
       adUnitConfig = this.adUnits.units[thisEl.dataset.adUnit];
       activeSizes = this.adSizesMatchingViewport(adUnitConfig.sizes)
-      if (activeSizes && activeSizes.length) {
-       this.fetchAPSBids(thisEl, activeSizes);
+      if (adUnitConfig.amazonEnabled && activeSizes && activeSizes.length) {
+       this.fetchAmazonBids(thisEl.id, activeSizes[1]);
       }
-      
 	}
 
     if (typeof window.headertag === 'undefined' || window.headertag.apiReady !== true) {

--- a/src/manager.js
+++ b/src/manager.js
@@ -103,24 +103,19 @@ AdManager.prototype.initGoogleTag = function() {
 /**
  * initializes A9
  * Fetch Amazon A9/Matchbuy/APS bids
- *
+ * Try to use the gpt slot.getSizes method to retrieve the active sizes given the viewport parameters inside the ad config.
+ * This method is undocumented, and could be removed. When not available, fall back to all sizes specified in the ad unit itself.
+ * This is not optimal, as sizes which cannot be displayed due to the viewport dimensions will be requested from A9. It is thus used as a fallback.
+ * See Docs here https://developers.google.com/doubleclick-gpt/reference#googletagslot
  * @returns undefined
 */
 AdManager.prototype.initAmazonA9 = function(element, slot) {
-  var gptSlotSizes = slot.getSizes();
-	
-  /**
-   * Try to use the gpt slot.getSizes method to retrieve the active sizes given the viewport parameters inside the ad config.
-   * This method is undocumented, and could be removed. When not available, fall back to all sizes specified in the ad unit itself.
-   * This is not optimal, as sizes which cannot be displayed due to the viewport dimensions will be requested from A9. It is thus used as a fallback.
-   * See Docs here https://developers.google.com/doubleclick-gpt/reference#googletagslot
-  */
 
-  adUnitConfig = this.adUnits.units[element.dataset.adUnit];
-  adUnitSizes = this.adUnitSizes(adUnitConfig.sizes)[1];
+  var adUnitConfig = this.adUnits.units[element.dataset.adUnit],
+    adUnitSizes = this.adUnitSizes(adUnitConfig.sizes)[1];
 
-  if (typeof gptSlotSizes == 'function') {
-    activeSizes = this.adSlotSizes(gptSlotSizes);
+  if (slot && typeof slot.getSizes == 'function') {
+    activeSizes = this.adSlotSizes(slot.getSizes());
   } else {
     activeSizes = adUnitSizes;
   }
@@ -550,9 +545,7 @@ AdManager.prototype.loadAds = function(element, updateCorrelator) {
   for (var i = 0; i < ads.length; i++) {
     var thisEl = ads[i],
       slot,
-      adUnitConfig,
-      activeSizes,
-      adUnitSizes;
+      activeSizes;
 
 	if ((thisEl.getAttribute('data-ad-load-state') === 'loaded') || (thisEl.getAttribute('data-ad-load-state') === 'loading')) {
       continue;

--- a/src/manager.js
+++ b/src/manager.js
@@ -105,17 +105,23 @@ AdManager.prototype.initGoogleTag = function() {
 */
 AdManager.prototype.fetchAmazonBids = function(elementId, gptSizes) {
 	
-	window.apstag.fetchBids({
-		slots: [{
-			slotID: elementId,
-			sizes: gptSizes
-		}],
-		timeout: 2e3
-	}, function (bids) {
-		// Your callback method, in this example it triggers the first DFP request for googletag's disableInitialLoad integration after bids have been set
-		window.headertag.cmd.push(function () {
-			window.apstag.setDisplayBids();
-		});
+  window.apstag.fetchBids({
+    slots: [{
+      slotID: elementId,
+      sizes: gptSizes
+    }],
+    timeout: 2e3
+	}, function(bids) {
+    // Your callback method, in this example it triggers the first DFP request for googletag's disableInitialLoad integration after bids have been set
+        if (typeof window.headertag === 'undefined' || window.headertag.apiReady !== true) {
+          window.googletag.cmd.push(function() {
+            window.apstag.setDisplayBids();
+          });
+        } else {
+          window.headertag.cmd.push(function() {
+            window.apstag.setDisplayBids();
+          });
+        }
 	});
 };
 

--- a/src/manager.js
+++ b/src/manager.js
@@ -132,27 +132,27 @@ AdManager.prototype.initAmazonA9 = function(element, slot) {
  * @returns undefined
 */
 AdManager.prototype.fetchAmazonBids = function(elementId, gptSizes) {
-	
   window.apstag.fetchBids({
     slots: [{
       slotID: elementId,
       sizes: gptSizes
     }],
     timeout: 2e3
-	}, function(bids) {
-    // Your callback method, in this example it triggers the first DFP request for googletag's disableInitialLoad integration after bids have been set
-        if (typeof window.headertag === 'undefined' || window.headertag.apiReady !== true) {
-          window.googletag.cmd.push(function() {
-            window.apstag.setDisplayBids();
-          });
-        } else {
-          window.headertag.cmd.push(function() {
-            window.apstag.setDisplayBids();
-          });
-        }
-	});
+	}, this.handleFetchedAmazonBids)
 };
 
+AdManager.prototype.handleFetchedAmazonBids = function(bids) {
+  // Your callback method, in this example it triggers the first DFP request for googletag's disableInitialLoad integration after bids have been set
+  if (typeof window.headertag === 'undefined' || window.headertag.apiReady !== true) {
+    window.googletag.cmd.push(function() {
+      window.apstag.setDisplayBids();
+    });
+  } else {
+    window.headertag.cmd.push(function() {
+      window.apstag.setDisplayBids();
+    });
+  }
+}
 
 /**
  * Sets global targeting regardless of ad slot based on the `TARGETING` global on each site

--- a/src/manager.js
+++ b/src/manager.js
@@ -412,7 +412,7 @@ AdManager.prototype.slotInfo = function() {
 AdManager.prototype.setSlotTargeting = function(element, slot, adUnitConfig) {
   var slotTargeting = {};
   var positionTargeting = adUnitConfig.pos || adUnitConfig.slotName || element.dataset.adUnit;
-  var kinjaPairs = TargetingPairs.getTargetingPairs(AdZone.forcedAdZone()).slotOptions;
+  var kinjaPairs = TargetingPairs.getTargetingPairs(AdZone.forcedAdZone(), adUnitConfig.pos).slotOptions;
 
   if (element.dataset.targeting) {
     slotTargeting = JSON.parse(element.dataset.targeting);


### PR DESCRIPTION
### What does this PR do? How does it affect users?
Adds multi-slot amazon a9 implementation dubbed `apstag` Docs here: https://app.asana.com/0/366985625403531/400333793598980

### How should this be tested (feature switches, URLs, special user permissions)?
It must be used in conjunction with the onion ad manager.  There is no legacy support for `Ad.Module`, however the backbone ad code in `ads.slotmodel`, `ads.controller` are still supported.
?onion_ad_manager&amazon_aps_tag

Test page:
http://lifehacker.dev:9000/?onion_ad_manager=on&amazon_aps_tag=on

Corresponding Changes in mantle:
https://github.com/gawkermedia/kinja-mantle/pull/12321

### Related Asana task, wiki page or blog posts
https://app.asana.com/0/366985625403531/400333793598980
