### PR TITLE
Htl sizefix

### DIFF
--- a/src/manager.js
+++ b/src/manager.js
@@ -314,6 +314,12 @@ AdManager.prototype.getClientWidth = function () {
  * @returns {Array} An array of ad sizes belonging to the slot
 */
 AdManager.prototype.adUnitSizes = function(sizeMap) {
+  if (sizeMap == 'fluid') {
+    return 'fluid';
+  }
+  if (sizeMap.length == 2 && typeof sizeMap[0] === 'number' && typeof sizeMap[1] === 'number') {
+    return sizeMap;
+  }
   var that = this;
   var validSizesIndex = 0;
   var sizeMapWidths = sizeMap.map(function(sizing, mapIndex) {

--- a/src/manager.spec.js
+++ b/src/manager.spec.js
@@ -573,6 +573,26 @@ describe('AdManager', function() {
         expect(adManager.adUnitSizes(sizeMap)).to.eql([[300,250], [728,90]]);
       });
     });
+
+    context('sizes are a 1d array', function () {
+      beforeEach(function() {
+        TestHelper.stub(adManager, 'getClientWidth').returns(1000);
+      });
+
+      it('returns the size', function() {
+        expect(adManager.adUnitSizes([300, 250])).to.eql([300,250]);
+      });
+    });
+
+    context('size is the "fluid" keyword', function () {
+      beforeEach(function() {
+        TestHelper.stub(adManager, 'getClientWidth').returns(1000);
+      });
+
+      it('returns the size', function() {
+        expect(adManager.adUnitSizes('fluid')).to.eql('fluid');
+      });
+    });
   });
 
   describe('#buildSizeMap', function () {

--- a/src/manager.spec.js
+++ b/src/manager.spec.js
@@ -1040,6 +1040,30 @@ describe('AdManager', function() {
       $(baseContainer).remove();
     });
 
+
+
+
+    context('outOfPage', function() {
+      beforeEach(function() {
+        TestHelper.stub(adManager, 'adUnitSizes');
+
+        // create an OOP slot
+        $(adSlot1).attr('data-ad-unit', 'dfp-ad-1');
+        adManager.adUnits.units = {
+          'dfp-ad-1': {
+            'slotName': 'dfp-ad-1',
+            'outOfPage': true
+          }
+        };
+      });
+
+      it('does not called adUnitSizes on outOfPage units', function() {
+        adManager.options.amazonEnabled = true;
+        adManager.loadAds('#dfp-ad-1');
+        expect(adManager.adUnitSizes.called).to.be.false;
+      });
+    });
+
     context('with wrapper tag', function() {
       beforeEach(function() {
 


### PR DESCRIPTION
This PR addresses two issues we've found with revised sizing code:

1. failure to handle the "fluid" keyword
2. failure to handle a flat array, like `[300, 250]` instead of a size-mapped array, like `[[[768,0],[[300,250]]`

It also adds a test case for a 3rd possibility -- the `out-of-page` slot. Both the old and new sizing code prevent the `adUnitSizes` function from being called on an `out-of-page` slot, rather than having `adUnitSizes` handle a `null` argument. Adding a test to show what happens in the "no sizing at all" case.