### PR TITLE
Allow window.gaVariation to be used and take priority if it is set

### DIFF
--- a/src/helpers/Experiments.js
+++ b/src/helpers/Experiments.js
@@ -3,6 +3,15 @@
 'use strict';
 
 var Experiments = {
+  getVariation: function (scope) {
+    if (typeof(scope.gaVariation) !== 'undefined') {
+      return scope.gaVariation;
+    } else if (scope.cxApi) {
+      return scope.cxApi.getChosenVariation(scope.gaExperimentId);
+    } else {
+      return null;
+    }
+  },
 
    /**
     * Retrieves the current Google Experiments variation.
@@ -13,7 +22,7 @@ var Experiments = {
 
   getExperimentVariation: function(scope) {
     var expScope = scope || window,
-      variation = expScope.cxApi ? expScope.cxApi.getChosenVariation(expScope.gaExperimentId) : null;
+      variation = this.getVariation(expScope);
     return (variation !== null && variation >= 0 && variation < 26) ? String.fromCharCode(variation + 65) : null;
   },
 

--- a/src/helpers/Experiments.spec.js
+++ b/src/helpers/Experiments.spec.js
@@ -6,6 +6,23 @@ describe('Experiments', function() {
   });
 
   describe('#getExperimentVariation', function() {
+    describe('uses window gaVariation if available', function() {
+      beforeEach(function() {
+        window.gaExperimentId = '456';
+        window.gaVariation = 0;
+        window.cxApi = undefined;
+      });
+
+      afterEach(() => {
+        window.gaExperimentId = undefined;
+        window.gaVariation = undefined;
+      });
+
+      it('returns letter A', function () {
+        expect(Experiments.getExperimentVariation()).to.equal('A');
+      });
+    });
+
     describe('chosen variation', function() {
       beforeEach(function() {
         window.gaExperimentId = '1234';


### PR DESCRIPTION
## What

This PR will use `window.gaVariation` if it is set, and take priority of that over using `window.cxApi`

## How to test

```
npm test
```