### PR TITLE
Hide the ad slot when it is empty.

### DIFF
--- a/src/manager.js
+++ b/src/manager.js
@@ -252,6 +252,7 @@ AdManager.prototype.onSlotRenderEnded = function (event) {
 
   if (event.isEmpty) {
     element.setAttribute('data-ad-load-state', 'empty');
+    element.style.display = 'none';
   } else {
 
     if (this.adUnits.units[element.dataset.adUnit].onSlotRenderEnded) {


### PR DESCRIPTION
This PR is to address the issue when the ad slot has `data-ad-load-state="empty"`. This introduces a blank block in the middle of content.

**Example of the issue:**
<img width="750" alt="screen shot 2018-05-07 at 2 13 01 pm" src="https://user-images.githubusercontent.com/36833757/39723056-28340a08-520a-11e8-8cfa-33b72740e8f4.png">

**Fix that sets `display: none` for the div**
<img width="1585" alt="screen shot 2018-05-07 at 2 50 12 pm" src="https://user-images.githubusercontent.com/36833757/39723123-6abf5b0c-520a-11e8-84bc-259b984ccb5a.png">

**Test link**
Using a link with all the flags that made this show up originally. The main one is that `bulbs_splashy_mid` is on.

http://offspring.lifehacker.localhost:9000/these-popular-toys-could-seriously-damage-your-kids-hea-1825782467?rev=1525461493484?bulbs_permalink_ads=off&bulbs_permalink_mobile_in_post=off&bulbs_splashy_mid=on&bulbs_stream_mobile=off&bulbs_stream_mobile_bottom=off