### PR TITLE
bug - use window.innerWidth

### DIFF
--- a/src/manager.js
+++ b/src/manager.js
@@ -29,7 +29,7 @@ var AdManager = function (options) {
   this.adId = 0;
   this.initialized = false;
   this.viewportWidth = 0;
-  this.oldViewportWidth = window.document.body.clientWidth;
+  this.oldViewportWidth = window.innerWidth;
   this.options = utils.extend(defaultOptions, options);
   this.bindContext();
 
@@ -90,7 +90,7 @@ AdManager.prototype.handleWindowResize = function () {
     return;
   }
 
-  this.viewportWidth = window.document.body.clientWidth;
+  this.viewportWidth = window.innerWidth;
 
   if (!this.oldViewportWidth || this.oldViewportWidth !== this.viewportWidth) {
     // viewport size has actually changed, reload ads
@@ -314,7 +314,7 @@ AdManager.prototype.generateId = function () {
   * @returns {Integer} client width in pixels
 */
 AdManager.prototype.getClientWidth = function () {
-  return window.document.body.clientWidth;
+  return window.innerWidth;
 };
 
 /**


### PR DESCRIPTION
What is this PR?
We were using `body.clientWidth`, however downstream we're calling `window.matchMedia()` which looks at `window.innerWidth`. This PR updates the width we want to examine and is consistent with what we will expect.

Also this bug fixes a production issue when your browser width is at 1024px - 1037px and the TOP_BANNER and LEFT_TOP ads do not show up as expected.