### PR TITLE
Fix (ads) Forced AdZone refactor

### DIFF
--- a/src/helpers/AdZone.js
+++ b/src/helpers/AdZone.js
@@ -28,12 +28,15 @@ var AdZone = {
   *
   * @returns String;
  */
-  forcedAdZone: function() {
+  forcedAdZone: function () {
+    var paramZone = this.getQueryParameter('adzone');
+    if (paramZone) {
+      return paramZone;
+    }
     if (!window.kinja) {
       return null;
     }
 
-    var paramZone = this.getQueryParameter('adzone');
     var postMeta = window.kinja.postMeta || {};
     var tags = postMeta.tags;
     var forceNonCollapse = /why your team sucks|wyts/.test(tags);
@@ -41,7 +44,7 @@ var AdZone = {
     var forceCollapseZone = !forceNonCollapse && forceCollapse ? 'collapse' : null;
     var post = postMeta.post;
     var postZone = post ? post.adZone : null;
-    return paramZone || forceCollapseZone || postZone;
+    return forceCollapseZone || postZone;
   }
-}
+};
 module.exports = AdZone;

--- a/src/helpers/AdZone.spec.js
+++ b/src/helpers/AdZone.spec.js
@@ -30,7 +30,18 @@ describe('AdZone', function() {
   	});
   });
 
-  describe('#forcedAdZone', function() {
+  describe('#forcedAdZone', function () {
+    describe('forced ad zone query param is null', function () {
+      beforeEach(function () {
+        TestHelper.stub(AdZone, 'locationSearch', '?adzone=');
+        window.kinja = {};
+      });
+
+      it('returns the forced ad zone param', function () {
+        expect(AdZone.forcedAdZone()).to.be.null;
+      });
+    });
+
     describe('kinja is not on window', function() {
       beforeEach(function() {
         delete window.kinja;

--- a/src/helpers/AdZone.spec.js
+++ b/src/helpers/AdZone.spec.js
@@ -31,14 +31,14 @@ describe('AdZone', function() {
   });
 
   describe('#forcedAdZone', function () {
-    describe('forced ad zone query param is null', function () {
+    describe('forced ad zone query param is present, but kinja is not on window', function () {
       beforeEach(function () {
-        TestHelper.stub(AdZone, 'locationSearch', '?adzone=');
-        window.kinja = {};
+        delete window.kinja;
+        TestHelper.stub(AdZone, 'locationSearch', '?adzone=reductress');
       });
 
       it('returns the forced ad zone param', function () {
-        expect(AdZone.forcedAdZone()).to.be.null;
+        expect(AdZone.forcedAdZone()).to.equal('reductress');
       });
     });
 


### PR DESCRIPTION
**What is it:**
This PR is to update the function `getForcedAdZone()`. Based on conversations in slack and the requirements of the ticket, it was determined that we need to check the query string parameter of `adzone`.  

<img width="793" alt="screen shot 2018-06-21 at 12 26 34 pm" src="https://user-images.githubusercontent.com/36833757/41735097-6618f8d0-754e-11e8-9526-491dde28a126.png">

**Asana Ticket:**
https://app.asana.com/0/366985625403531/682105519698537/f