### PR TITLE
Chore (ads) get targeting pair refactor

### DIFF
--- a/src/helpers/TargetingPairs.js
+++ b/src/helpers/TargetingPairs.js
@@ -13,7 +13,7 @@ var TargetingPairs = {
   *
   * @param Window scope the window to use for the kinja meta info
   */
-  getCategories: function(scope) {
+  getCategories: function (scope) {
     var categoryMeta = scope.kinja.categoryMeta || {},
       postMeta = scope.kinja.postMeta || {};
 
@@ -25,7 +25,7 @@ var TargetingPairs = {
   *
   * @param Window scope the window to use for the kinja meta info
   */
-  getTags: function(scope) {
+  getTags: function (scope) {
     var tagMeta = scope.kinja.tagMeta || scope.kinja.postMeta || {};
 
     return (tagMeta.tags || '').split(',');
@@ -37,7 +37,7 @@ var TargetingPairs = {
    * @param Window scope the window to use for the kinja meta info.
    *
    */
-  buildTargetingPairs: function(scope, positionTargeting) {
+  buildTargetingPairs: function (scope, positionTargeting) {
     var kinjaMeta = scope.kinja.meta,
       post = scope.kinja.postMeta || {},
       content = scope.kinja.postContentRatings || [],
@@ -80,7 +80,10 @@ var TargetingPairs = {
    * @param Window scope the window to use for the kinja meta info.
    *
    */
-  getTargetingPairs: function(forcedAdZone, positionTargeting) {
+  getTargetingPairs: function (forcedAdZone, positionTargeting) {
+    if (forcedAdZone && !window.kinja) {
+      return { pageOptions : { forcedAdZone : forcedAdZone} };
+    }
     if (!window.kinja) {
       return {};
     }

--- a/src/helpers/TargetingPairs.spec.js
+++ b/src/helpers/TargetingPairs.spec.js
@@ -202,17 +202,6 @@ describe('TargetingPairs', function() {
       });
     });
 
-    context('forced adzone exists but missing scope.kinja', function () {
-      beforeEach(function () {
-        delete window.kinja;
-      });
-
-      it('returns an object with a pageOptions.forcedAdZone property', function () {
-        var pairs =  TargetingPairs.getTargetingPairs('advertiser');
-        expect(pairs.pageOptions.forcedAdZone).to.equal('advertiser');
-      });
-    });
-
     context('without forced ad zone', function() {
       it('sets forced ad zone as false', function() {
         var pairs =  TargetingPairs.getTargetingPairs();
@@ -222,6 +211,17 @@ describe('TargetingPairs', function() {
 
     context('with forced ad zone', function() {
       it('uses forced ad zone', function() {
+        var pairs =  TargetingPairs.getTargetingPairs('advertiser');
+        expect(pairs.pageOptions.forcedAdZone).to.equal('advertiser');
+      });
+    });
+
+    context('forced adzone exists but missing scope.kinja', function () {
+      beforeEach(function () {
+        delete window.kinja;
+      });
+
+      it('returns an object with a pageOptions.forcedAdZone property', function () {
         var pairs =  TargetingPairs.getTargetingPairs('advertiser');
         expect(pairs.pageOptions.forcedAdZone).to.equal('advertiser');
       });

--- a/src/helpers/TargetingPairs.spec.js
+++ b/src/helpers/TargetingPairs.spec.js
@@ -202,6 +202,17 @@ describe('TargetingPairs', function() {
       });
     });
 
+    context('forced adzone exists but missing scope.kinja', function () {
+      beforeEach(function () {
+        delete window.kinja;
+      });
+
+      it('returns an object with a pageOptions.forcedAdZone property', function () {
+        var pairs =  TargetingPairs.getTargetingPairs('advertiser');
+        expect(pairs.pageOptions.forcedAdZone).to.equal('advertiser');
+      });
+    });
+
     context('without forced ad zone', function() {
       it('sets forced ad zone as false', function() {
         var pairs =  TargetingPairs.getTargetingPairs();


### PR DESCRIPTION
This PR refactors the `getTargetingPairs()` to account for third party users of our library, such as Reductress.