### PR TITLE
Merge targeting global with targeting pairs logic

### DIFF
--- a/src/manager.js
+++ b/src/manager.js
@@ -118,7 +118,7 @@ AdManager.prototype.initGoogleTag = function () {
   this.googletag.pubads().addEventListener('impressionViewable', adManager.onImpressionViewable);
   this.googletag.pubads().addEventListener('slotOnload', adManager.onSlotOnload);
 
-  this.targeting = global.TARGETING || TargetingPairs.getTargetingPairs(AdZone.forcedAdZone()).pageOptions;
+  this.targeting = utils.extend(global.TARGETING || {}, TargetingPairs.getTargetingPairs(AdZone.forcedAdZone()).pageOptions);
 
   this.setPageTargeting();
 

--- a/src/manager.spec.js
+++ b/src/manager.spec.js
@@ -179,6 +179,19 @@ describe('AdManager', function() {
       adManager.initGoogleTag();
     });
 
+    context('TARGETING global, and a forced ad zone', function () {
+      beforeEach(function() {
+        window.TARGETING = { 'dfpcontentid': 'foo-bar-baz' };
+        TestHelper.stub(AdZone, 'forcedAdZone').returns('adtest');
+        adManager.initGoogleTag();
+      });
+
+      it('merges pre-existing contextual targeting with forced ad zone', function() {
+        expect(adManager.targeting.dfpcontentid).to.equal('foo-bar-baz');
+        expect(adManager.targeting.forcedAdZone).to.equal('adtest');
+      });
+    });
+
     it('- enable single request mode when option enabled, otherwise disable it', function() {
       expect(adManager.googletag.pubads().enableSingleRequest.called).to.be.false;
       adManager.options.enableSRA = true;


### PR DESCRIPTION
Merge TARGETING global with targeting pairs instead of using one or the other, so forced ad zone can co-exist