### PR TITLE
Fixed an issue with a9 bidding

### DIFF
--- a/src/manager.js
+++ b/src/manager.js
@@ -138,7 +138,7 @@ AdManager.prototype.fetchAmazonBids = function (slotsToFetch) {
     indexExchangeEnabled = this.options.indexExchangeEnabled,
     slots;
 
-  if (typeof(slotsToFetch) === 'undefined' || slotsToFetch.length < 1) {
+  if (typeof(slotsToFetch) === 'undefined') {
     return;
   }
 
@@ -151,6 +151,10 @@ AdManager.prototype.fetchAmazonBids = function (slotsToFetch) {
       slotName: adUnitPath + '_' + slot.slotName
     };
   });
+
+  if (slots.length < 1) {
+    return;
+  }
 
   if (this.options.debug) {
     console.info("Fetching a9 bid requests for slots: ", slots);

--- a/src/manager.js
+++ b/src/manager.js
@@ -152,6 +152,10 @@ AdManager.prototype.fetchAmazonBids = function (slotsToFetch) {
     };
   });
 
+  if (this.options.debug) {
+    console.info("Fetching a9 bid requests for slots: ", slots);
+  }
+
   window.apstag.fetchBids({
     slots: slots,
     timeout: 300

--- a/src/manager.js
+++ b/src/manager.js
@@ -146,7 +146,7 @@ AdManager.prototype.fetchAmazonBids = function (slotsToFetch) {
     return !slot.getOutOfPage() && slot.activeSizes[0] !== 'fluid' && slot.activeSizes.length > 0;
   }).map(function (slot) {
     return {
-      slotId: slot.getSlotElementId(),
+      slotID: slot.getSlotElementId(),
       sizes: slot.activeSizes,
       slotName: adUnitPath + '_' + slot.slotName
     };

--- a/src/manager.js
+++ b/src/manager.js
@@ -143,7 +143,7 @@ AdManager.prototype.fetchAmazonBids = function (slotsToFetch) {
   }
 
   slots = slotsToFetch.filter(function (slot) {
-    return !slot.getOutOfPage();
+    return !slot.getOutOfPage() && slot.activeSizes[0] !== 'fluid';
   }).map(function (slot) {
     return {
       slotId: slot.getSlotElementId(),

--- a/src/manager.js
+++ b/src/manager.js
@@ -133,23 +133,32 @@ AdManager.prototype.initGoogleTag = function () {
  *
  * @returns undefined
 */
-AdManager.prototype.fetchAmazonBids = function (elementId, gptSizes, slotName) {
+AdManager.prototype.fetchAmazonBids = function (slotsToFetch) {
   var adUnitPath = this.getAdUnitCode(),
-    slotUnit = adUnitPath + '_' + slotName,
-    timeoutAmount = 300,
-    indexExchangeEnabled = this.options.indexExchangeEnabled;
+    indexExchangeEnabled = this.options.indexExchangeEnabled,
+    slots;
+
+  if (typeof(slotsToFetch) === 'undefined' || slotsToFetch.length < 1) {
+    return;
+  }
+
+  slots = slotsToFetch.filter(function (slot) {
+    return !slot.getOutOfPage();
+  }).map(function (slot) {
+    return {
+      slotId: slot.getSlotElementId(),
+      sizes: slot.activeSizes,
+      slotName: adUnitPath + '_' + slot.slotName
+    };
+  });
 
   window.apstag.fetchBids({
-    slots: [{
-      slotID: elementId,
-      sizes: gptSizes,
-      slotName: slotUnit
-    }],
-    timeout: timeoutAmount
+    slots: slots,
+    timeout: 300
   }, callback = function (bids) {
     /* Your callback method, in this example it triggers the first DFP request
     for googletag's disableInitialLoad integration after bids have been set */
-    if (indexExchangeEnabled) {
+    if (indexExchangeEnabled && typeof(window.headertag) !== 'undefined') {
       window.headertag.cmd.push(function () {
         window.apstag.setDisplayBids();
       });
@@ -548,6 +557,8 @@ AdManager.prototype.configureAd = function (element) {
     slot.prebid = adUnitConfig.prebid;
   }
 
+  slot.slotName = adUnitConfig.slotName;
+
   this.slots[element.id] = slot;
 
   return slot;
@@ -622,23 +633,6 @@ AdManager.prototype.loadAds = function (element, updateCorrelator, useScopedSele
 
     if (slot && slot.eagerLoad) {
       slotsToLoad.push(slot);
-    }
-
-    if (this.options.amazonEnabled && !adUnitConfig.outOfPage) {
-      /**
-       * Try to use the gpt slot.getSizes method to retrieve the active sizes given the viewport parameters
-       * inside the ad config.
-       * This method is undocumented, and could be removed. When not available, fall back to all sizes
-       * specified in the ad unit itself.
-       * This is not optimal, as sizes which cannot be displayed due to the viewport dimensions will be
-       * requested from A9. It is thus used as a fallback.
-       * See Docs here https://developers.google.com/doubleclick-gpt/reference#googletagslot
-      */
-      activeSizes = slot.activeSizes
-
-      if (adUnitConfig.amazonEnabled && activeSizes && activeSizes.length) {
-        this.fetchAmazonBids(thisEl.id, activeSizes, adUnitConfig.slotName);
-      }
     }
 
     if (typeof window.headertag === 'undefined' || window.headertag.apiReady !== true || !this.options.indexExchangeEnabled) {
@@ -745,6 +739,11 @@ AdManager.prototype.refreshSlots = function (slotsToLoad) {
   var useIAS = typeof this.__iasPET !== 'undefined' && this.options.iasEnabled;
   var useIndex = typeof window.headertag !== 'undefined' && window.headertag.apiReady === true && this.options.indexExchangeEnabled;
   var usePrebid = typeof window.pbjs !== 'undefined' && this.options.prebidEnabled;
+  var useAmazon = typeof window.apstag !== 'undefined' && this.options.amazonEnabled;
+
+  if (useAmazon) {
+    this.fetchAmazonBids(slotsToLoad);
+  }
 
   if (useIAS) {
     this.fetchIasTargeting();

--- a/src/manager.js
+++ b/src/manager.js
@@ -143,7 +143,7 @@ AdManager.prototype.fetchAmazonBids = function (slotsToFetch) {
   }
 
   slots = slotsToFetch.filter(function (slot) {
-    return !slot.getOutOfPage() && slot.activeSizes[0] !== 'fluid';
+    return !slot.getOutOfPage() && slot.activeSizes[0] !== 'fluid' && slot.activeSizes.length > 0;
   }).map(function (slot) {
     return {
       slotId: slot.getSlotElementId(),

--- a/src/manager.spec.js
+++ b/src/manager.spec.js
@@ -1415,6 +1415,21 @@ describe('AdManager', function() {
       expect(fetchedSlots[0].slotId).to.equal(slots[0].getSlotElementId());
     });
 
+    it('- does not include slots which currently have no allowed creative sizes based on the current viewport', function () {
+      slots.push({
+          getSlotElementId: function () { return 'dfp-ad-20'; },
+          getOutOfPage: function () { return false; },
+          activeSizes: [],
+          slotName: 'non-viewport-slot'
+      });
+      adManager.fetchAmazonBids(slots);
+      expect(window.apstag.fetchBids.called).to.be.true;
+      var fetchedSlots = window.apstag.fetchBids.args[0][0].slots;
+
+      expect(fetchedSlots.length).to.equal(1);
+      expect(fetchedSlots[0].slotId).to.equal(slots[0].getSlotElementId());
+    });
+
     it('- does not include native slots (sizes `fluid`)', function () {
       slots.push({
           getSlotElementId: function () { return 'dfp-ad-20'; },

--- a/src/manager.spec.js
+++ b/src/manager.spec.js
@@ -1395,7 +1395,7 @@ describe('AdManager', function() {
       var fetchedSlots = window.apstag.fetchBids.args[0][0].slots;
 
       expect(fetchedSlots.length).to.equal(1);
-      expect(fetchedSlots[0].slotId).to.equal(slots[0].getSlotElementId());
+      expect(fetchedSlots[0].slotID).to.equal(slots[0].getSlotElementId());
       expect(fetchedSlots[0].sizes).to.equal(slots[0].activeSizes);
       expect(fetchedSlots[0].slotName).to.equal('/4246/fmg.onion_' + slots[0].slotName);
     });
@@ -1412,7 +1412,7 @@ describe('AdManager', function() {
       var fetchedSlots = window.apstag.fetchBids.args[0][0].slots;
 
       expect(fetchedSlots.length).to.equal(1);
-      expect(fetchedSlots[0].slotId).to.equal(slots[0].getSlotElementId());
+      expect(fetchedSlots[0].slotID).to.equal(slots[0].getSlotElementId());
     });
 
     it('- does not include slots which currently have no allowed creative sizes based on the current viewport', function () {
@@ -1427,7 +1427,7 @@ describe('AdManager', function() {
       var fetchedSlots = window.apstag.fetchBids.args[0][0].slots;
 
       expect(fetchedSlots.length).to.equal(1);
-      expect(fetchedSlots[0].slotId).to.equal(slots[0].getSlotElementId());
+      expect(fetchedSlots[0].slotID).to.equal(slots[0].getSlotElementId());
     });
 
     it('- does not include native slots (sizes `fluid`)', function () {
@@ -1442,7 +1442,7 @@ describe('AdManager', function() {
       var fetchedSlots = window.apstag.fetchBids.args[0][0].slots;
 
       expect(fetchedSlots.length).to.equal(1);
-      expect(fetchedSlots[0].slotId).to.equal(slots[0].getSlotElementId());
+      expect(fetchedSlots[0].slotID).to.equal(slots[0].getSlotElementId());
     });
 
     it('- sets targeting once bids are returned from apstag api', function (done) {

--- a/src/manager.spec.js
+++ b/src/manager.spec.js
@@ -1415,6 +1415,21 @@ describe('AdManager', function() {
       expect(fetchedSlots[0].slotId).to.equal(slots[0].getSlotElementId());
     });
 
+    it('- does not include native slots (sizes `fluid`)', function () {
+      slots.push({
+          getSlotElementId: function () { return 'dfp-ad-20'; },
+          getOutOfPage: function () { return false; },
+          activeSizes: ['fluid'],
+          slotName: 'native'
+      });
+      adManager.fetchAmazonBids(slots);
+      expect(window.apstag.fetchBids.called).to.be.true;
+      var fetchedSlots = window.apstag.fetchBids.args[0][0].slots;
+
+      expect(fetchedSlots.length).to.equal(1);
+      expect(fetchedSlots[0].slotId).to.equal(slots[0].getSlotElementId());
+    });
+
     it('- sets targeting once bids are returned from apstag api', function (done) {
       adManager.fetchAmazonBids(slots);
       callback();

--- a/src/manager.spec.js
+++ b/src/manager.spec.js
@@ -1430,6 +1430,17 @@ describe('AdManager', function() {
       expect(fetchedSlots[0].slotID).to.equal(slots[0].getSlotElementId());
     });
 
+    it('- does not call fetchBids if none of the slots passed in have valid sizes for the viewport', function () {
+      slots = [{
+          getSlotElementId: function () { return 'dfp-ad-20'; },
+          getOutOfPage: function () { return false; },
+          activeSizes: [],
+          slotName: 'non-viewport-slot'
+      }];
+      adManager.fetchAmazonBids(slots);
+      expect(window.apstag.fetchBids.called).to.be.false;
+    });
+
     it('- does not include native slots (sizes `fluid`)', function () {
       slots.push({
           getSlotElementId: function () { return 'dfp-ad-20'; },

--- a/src/manager.spec.js
+++ b/src/manager.spec.js
@@ -1028,6 +1028,10 @@ describe('AdManager', function() {
         expect(slotStub.activeSizes).to.deep.equal(sizes);
       });
 
+      it('- defines slotName to be used in a9 amazon header bidding', function() {
+        expect(slotStub.slotName).to.equal('header');
+      });
+
       it('- returns the configured slot and adds it to the slots object', function() {
         expect(typeof adManager.slots['dfp-ad-1'].addService).to.equal('function');
       });
@@ -1110,7 +1114,7 @@ describe('AdManager', function() {
       TestHelper.stub(adManager.googletag, 'enableServices');
       TestHelper.stub(adManager, 'fetchAmazonBids');
 
-      it('- no call to fetchAmazonBids if parameter amazonEnalbed is false', function() {
+      it('- no call to fetchAmazonBids if parameter amazonEnabled is false', function() {
         expect(adManager.fetchAmazonBids.calledOnce).to.be.true;
         adManager.options.amazonEnabled = false;
         adManager.initGoogleTag();
@@ -1341,23 +1345,43 @@ describe('AdManager', function() {
   });
 
   describe('#fetchAmazonBids', function () {
+    var slots;
 
     beforeEach(function() {
      var headertag = window.headertag = {};
       sandbox = sinon.sandbox.create();
       window.apstag = {
         fetchBids: function () {
-      this.callArg(callback)
-    }
+          this.callArg(callback);
+        },
+        setDisplayBids: function () {}
       };
 
       headertag.cmd = {
         push: function() {
-         window.apstag.setDisplayBids()
+          window.apstag.setDisplayBids();
         }
       };
 
-      sandbox.stub(window.headertag.cmd, 'push')
+      window.googletag = {
+        cmd: {
+          push: function () {
+            window.apstag.setDisplayBids();
+          }
+        }
+      };
+
+      slots = [
+        {
+          getSlotElementId: function () { return 'dfp-ad-1'; },
+          getOutOfPage: function () { return false; },
+          activeSizes: [[728, 90]],
+          slotName: 'header'
+        }
+      ];
+
+      sandbox.stub(window.headertag.cmd, 'push');
+      sandbox.stub(window.googletag.cmd, 'push');
       sandbox.stub(window.apstag, 'fetchBids');
     });
 
@@ -1366,19 +1390,44 @@ describe('AdManager', function() {
     });
 
     it('- call to apstag functions if apstag is defined', function () {
-      adManager.fetchAmazonBids();
+      adManager.fetchAmazonBids(slots);
       expect(window.apstag.fetchBids.called).to.be.true;
+      var fetchedSlots = window.apstag.fetchBids.args[0][0].slots;
+
+      expect(fetchedSlots.length).to.equal(1);
+      expect(fetchedSlots[0].slotId).to.equal(slots[0].getSlotElementId());
+      expect(fetchedSlots[0].sizes).to.equal(slots[0].activeSizes);
+      expect(fetchedSlots[0].slotName).to.equal('/4246/fmg.onion_' + slots[0].slotName);
     });
 
-    it('- fetches bids from apstag api', function (done) {
-      adManager.fetchAmazonBids();
+    it('- does not include out of page slots', function () {
+      slots.push({
+          getSlotElementId: function () { return 'dfp-ad-20'; },
+          getOutOfPage: function () { return true; },
+          activeSizes: [[728, 90]],
+          slotName: 'out-of-page'
+      });
+      adManager.fetchAmazonBids(slots);
+      expect(window.apstag.fetchBids.called).to.be.true;
+      var fetchedSlots = window.apstag.fetchBids.args[0][0].slots;
+
+      expect(fetchedSlots.length).to.equal(1);
+      expect(fetchedSlots[0].slotId).to.equal(slots[0].getSlotElementId());
+    });
+
+    it('- sets targeting once bids are returned from apstag api', function (done) {
+      adManager.fetchAmazonBids(slots);
       callback();
       expect(window.headertag.cmd.push.calledOnce).to.be.true;
       done();
     });
 
-    it('- no call to apstag functions if apstag is undefined', function () {
-      expect(window.apstag.fetchBids.called).to.be.false;
+    it('- sets targeting using googletag if Index not on page once bids are returned from apstag api', function (done) {
+      delete window.headertag;
+      adManager.fetchAmazonBids(slots);
+      callback();
+      expect(window.googletag.cmd.push.calledOnce).to.be.true;
+      done();
     });
   });
 
@@ -1469,6 +1518,7 @@ describe('AdManager', function() {
         adManager.options.amazonEnabled = false;
 
         TestHelper.stub(adManager, 'prebidRefresh');
+        TestHelper.stub(adManager, 'fetchAmazonBids');
       });
 
       afterEach(function() {
@@ -1489,6 +1539,37 @@ describe('AdManager', function() {
 
     });
 
+    context('> amazonEnabled', function() {
+      var adSlot, baseContainer;
+      beforeEach(function(){
+        var setupRefs = adSlotSetup();
+        adSlot = setupRefs.adSlot1;
+        baseContainer = setupRefs.baseContainer;
+      });
+
+      afterEach(function() {
+        $(baseContainer).remove();
+      });
+
+      it('- calls fetchAmazonBids when enabled', function() {
+        adManager = AdManagerWrapper.init({ amazonEnabled: true });
+        TestHelper.stub(adManager, 'fetchAmazonBids');
+
+        adManager.refreshSlots([adSlot]);
+
+        expect(adManager.fetchAmazonBids.called).to.be.true;
+      });
+
+      it('- does not calls fetchIasTargeting when enabled', function() {
+        adManager = AdManagerWrapper.init({ amazonEnabled: false });
+        TestHelper.stub(adManager, 'fetchAmazonBids');
+
+        adManager.refreshSlots([adSlot]);
+
+        expect(adManager.fetchAmazonBids.called).to.be.false;
+      });
+    });
+
     context('> iasEnabled', function(){
       var adSlot, baseContainer;
       beforeEach(function(){
@@ -1503,6 +1584,7 @@ describe('AdManager', function() {
 
       it('- calls fetchIasTargeting when enabled', function() {
         adManager = AdManagerWrapper.init({ iasEnabled: true });
+        TestHelper.stub(adManager, 'fetchAmazonBids');
         TestHelper.stub(adManager, 'fetchIasTargeting');
 
         adManager.refreshSlots([adSlot]);
@@ -1512,6 +1594,7 @@ describe('AdManager', function() {
 
       it('- does not calls fetchIasTargeting when enabled', function() {
         adManager = AdManagerWrapper.init({ iasEnabled: false });
+        TestHelper.stub(adManager, 'fetchAmazonBids');
         TestHelper.stub(adManager, 'fetchIasTargeting');
 
         adManager.refreshSlots([adSlot]);


### PR DESCRIPTION
Fixed an issue with a9 bidding not correctly being invoked for lazy-loaded ads, and also cleaned up the logic a bit as part of this update.  Note, instructions for how to test this PR (other than the unit test coverage here) are provided in the Mantle PR