### PR TITLE
Remove any manual use of the correlator param

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # bulbs-public-ads-manager
-Ads manager for public side of sites. Fills in ad slots. 
+Ads manager for public side of sites. Fills in ad slots.
 See a [simple visual overview](https://docs.google.com/drawings/d/1zwLspXOvd5nVZUH3F_UpoDxqp5ou72XzfyA2QVMlAg0) of the programmatic ad process.
 
 ## Setup
@@ -25,7 +25,7 @@ See a [simple visual overview](https://docs.google.com/drawings/d/1zwLspXOvd5nVZ
 
 `google gpt` - The main google library that provides access to the DFP ad server.
 
-`index exchange` - Header bidding wrapper. This library wraps functions contained within google gpt. It conducts a front-end auction where ad networks compete for the best price. Once each price, the price is appended to the corresponding ad call, which directs the request to the correct campaign in DFP. Each price range for each bidder maps to line item creative inside google DFP. 
+`index exchange` - Header bidding wrapper. This library wraps functions contained within google gpt. It conducts a front-end auction where ad networks compete for the best price. Once each price, the price is appended to the corresponding ad call, which directs the request to the correct campaign in DFP. Each price range for each bidder maps to line item creative inside google DFP.
 
 These price-based lines are auto generated ahead of time through index exchange via the google DFP API. These lines are created at the time of integration and aren't generally modified unless there's a major change to index's internal API.
 
@@ -36,10 +36,6 @@ These price-based lines are auto generated ahead of time through index exchange 
 ### Features and Terminology
 
 `SRA` - Single request Architecture. Allows multiple ad request to be consolidated into the same http request. The benefits of this are both load time performance as elimination of async issues pertaining to the order in which ads are returned. According to google, SRA is the only way to guarantee roadblock delivery. Additional docs [here](https://support.google.com/dfp_premium/answer/177277?hl=en)
-
-`Correlator` - A correlator is a randomly generated number which is sent alongside each ad request. Ad requests made within a 30 second window keep the same correlator. This value is used to tie ad impressions to a single pageview. This becomes most relevant when roadblocks (aka takeovers) are in play. If a multiple-ad takeover is delivered through DFP, the correlator will tie together each request to ensure that ads are delivered together.
-
-The downside to this is that ad requests with mathching correlators can only deliver each creative contained in the corresponding line item once. So for example if a direct (takeover) campaign contains only 2 ads, but a page has 4 ad slots on it, 2 of the ad slots won't deliver an ad.
 
 `eagerLoad` - Indicates that an ad request is made immediately on page load. The opposite of this is often called dynamically loaded or waypoint loaded.
 
@@ -56,11 +52,11 @@ $ npm test
 ```
 
 Tests will run on travis-ci as part of the pull request process.
-The tests are primarily comprised of:  
+The tests are primarily comprised of:
 - [Sinon Mocks And Stubs](http://sinonjs.org/releases/v5.1.0/)
-- [Chai's BDD style of assertions](http://www.chaijs.com/api/bdd/)  
+- [Chai's BDD style of assertions](http://www.chaijs.com/api/bdd/)
 - inside of a [Mocha framework](https://mochajs.org/#interfaces)
-- run with [Karma v0.13](https://karma-runner.github.io/0.13/index.html)  
+- run with [Karma v0.13](https://karma-runner.github.io/0.13/index.html)
 
 We try to maintain code coverage as new functions are added.
 

--- a/src/manager.js
+++ b/src/manager.js
@@ -109,7 +109,6 @@ AdManager.prototype.initGoogleTag = function () {
   var adManager = this;
   this.googletag.pubads().disableInitialLoad();
   this.googletag.pubads().enableAsyncRendering();
-  this.googletag.pubads().updateCorrelator();
 
   if (this.options.enableSRA) {
     this.googletag.pubads().enableSingleRequest();
@@ -247,7 +246,6 @@ AdManager.prototype.setUtmTargeting = function () {
  * @returns undefined
 */
 AdManager.prototype.reloadAds = function (element) {
-  this.googletag.pubads().updateCorrelator();
   this.unloadAds(element);
   this.loadAds(element);
 };
@@ -577,10 +575,9 @@ AdManager.prototype.unpause = function () {
  * Loads all ads
  *
  * @param {Element} optional element to scope where to load ads in the document
- * @param {updateCorrelator} optional flag to force an update of the correlator value
  * @returns undefined
 */
-AdManager.prototype.loadAds = function (element, updateCorrelator, useScopedSelector) {
+AdManager.prototype.loadAds = function (element, useScopedSelector) {
   if (this.paused || !this.initialized) {
     return;
   }
@@ -590,10 +587,6 @@ AdManager.prototype.loadAds = function (element, updateCorrelator, useScopedSele
 
   if (!this.googletag.pubadsReady) {
     this.googletag.enableServices();
-  }
-
-  if (updateCorrelator) {
-    this.googletag.pubads().updateCorrelator();
   }
 
   for (var i = 0; i < ads.length; i++) {
@@ -751,11 +744,11 @@ AdManager.prototype.refreshSlots = function (slotsToLoad) {
   }
 
   if (useIndex) {
-    window.headertag.pubads().refresh(slotsToLoad, {changeCorrelator: false});
+    window.headertag.pubads().refresh(slotsToLoad);
   } else if (usePrebid) {
     this.prebidRefresh(slotsToLoad);
   } else {
-    this.googletag.pubads().refresh(slotsToLoad, {changeCorrelator: false});
+    this.googletag.pubads().refresh(slotsToLoad);
   }
 };
 

--- a/src/manager.spec.js
+++ b/src/manager.spec.js
@@ -170,7 +170,6 @@ describe('AdManager', function() {
         refresh: sinon.spy(),
         clear: sinon.spy(),
         setTargeting: sinon.spy(),
-        updateCorrelator: sinon.spy(),
         enableAsyncRendering: sinon.spy()
       });
       TestHelper.stub(adManager, 'setPageTargeting');
@@ -204,12 +203,8 @@ describe('AdManager', function() {
       expect(adManager.googletag.pubads().disableInitialLoad.called).to.be.true;
     });
 
-    it('- enables async rendering to avoid page blocking and allow the manual use of `updateCorrelator`', function() {
+    it('- enables async rendering to avoid page blocking', function() {
       expect(adManager.googletag.pubads().enableAsyncRendering.called).to.be.true;
-    });
-
-    it('- always updates the correlator automatically whenever the ad lib is loaded', function() {
-      expect(adManager.googletag.pubads().updateCorrelator.called).to.be.true;
     });
 
     it('- sets up custom slot render ended callback', function() {
@@ -390,9 +385,6 @@ describe('AdManager', function() {
 
   describe('#reloadAds', function() {
     beforeEach(function() {
-      TestHelper.stub(adManager.googletag, 'pubads').returns({
-        updateCorrelator: sinon.spy()
-      });
       TestHelper.stub(adManager, 'unloadAds');
       TestHelper.stub(adManager, 'loadAds');
       adManager.reloadAds('domElement');
@@ -401,10 +393,6 @@ describe('AdManager', function() {
     it('- unloads and reloads ads', function() {
       expect(adManager.unloadAds.calledWith('domElement')).to.be.true;
       expect(adManager.loadAds.calledWith('domElement')).to.be.true;
-    });
-
-    it('- updates the correlator so it is treated like a new pageview request', function() {
-      expect(googletag.pubads().updateCorrelator.called).to.be.true;
     });
   });
 
@@ -1101,7 +1089,6 @@ describe('AdManager', function() {
         enableSingleRequest: sinon.spy(),
         disableInitialLoad: sinon.spy(),
         addEventListener: sinon.spy(),
-        updateCorrelator: sinon.spy(),
         refresh: sinon.spy(),
         clear: sinon.spy(),
         setTargeting: sinon.spy()
@@ -1274,16 +1261,6 @@ describe('AdManager', function() {
 
       it('- does not try to refresh pubads across the board', function() {
         expect(adManager.googletag.pubads().refresh.called).to.be.false;
-      });
-    });
-
-    context('> update correlator true', function() {
-      beforeEach(function() {
-        adManager.loadAds(undefined, true);
-      });
-
-      it('- updates the correlator', function() {
-        expect(adManager.googletag.pubads().updateCorrelator.called).to.be.true;
       });
     });
 


### PR DESCRIPTION
Google did away with the relevance of the correlator param with the latest releases of the GPT.js library. 
 It now uses a long-living client side page token to determine when requests are still part of the same pageview (https://support.google.com/admanager/answer/183281)