### PR TITLE
Add ad position index targeting to each of the ad calls

### DIFF
--- a/src/manager.js
+++ b/src/manager.js
@@ -27,6 +27,7 @@ var AdManager = function (options) {
   /* adUnits comes from ad-units.js */
   this.adUnits = options.adUnits;
   this.slots = {};
+  this.countsByAdSlot = {};
   this.adId = 0;
   this.initialized = false;
   this.viewportWidth = 0;
@@ -482,10 +483,14 @@ AdManager.prototype.slotInfo = function () {
 */
 AdManager.prototype.setSlotTargeting = function (element, slot, adUnitConfig) {
   var slotTargeting = element.dataset.targeting ? JSON.parse(element.dataset.targeting) : {};
-  var positionTargeting = adUnitConfig.pos || slotTargeting.pos || adUnitConfig.slotName || element.dataset.adUnit;
-  var kinjaPairs = TargetingPairs.getTargetingPairs(AdZone.forcedAdZone(), positionTargeting).slotOptions;
+  slotTargeting.pos = slotTargeting.pos || adUnitConfig.pos || adUnitConfig.slotName || element.dataset.adUnit;
+  var kinjaPairs = TargetingPairs.getTargetingPairs(AdZone.forcedAdZone(), slotTargeting.pos).slotOptions;
+  var adSlotCount = (this.countsByAdSlot[slotTargeting.pos] || 0) + 1;
 
   slotTargeting = utils.extend(kinjaPairs, slotTargeting);
+
+  slotTargeting.ad_index = adSlotCount;
+  this.countsByAdSlot[slotTargeting.pos] = adSlotCount;
 
   for (var customKey in slotTargeting) {
     if (slotTargeting[customKey]) {

--- a/src/manager.js
+++ b/src/manager.js
@@ -493,6 +493,8 @@ AdManager.prototype.setSlotTargeting = function (element, slot, adUnitConfig) {
       slot.setTargeting(customKey, slotTargeting[customKey].toString());
     }
   }
+
+  this.setIndexTargetingForSlots([slot]);
 };
 
 AdManager.prototype.getAdUnitCode = function () {
@@ -760,8 +762,6 @@ AdManager.prototype.refreshSlots = function (slotsToLoad) {
   if (slotsToLoad.length === 0) {
     return;
   }
-
-  this.setIndexTargetingForSlots(slotsToLoad);
 
   var useIAS = typeof this.__iasPET !== 'undefined' && this.options.iasEnabled;
   var useIndex = typeof window.headertag !== 'undefined' && window.headertag.apiReady === true && this.options.indexExchangeEnabled;

--- a/src/manager.js
+++ b/src/manager.js
@@ -740,7 +740,6 @@ AdManager.prototype.fetchIasTargeting = function () {
  * @returns undefined
 */
 AdManager.prototype.setIndexTargetingForSlots = function (slots) {
-  debugger
   for (var i = 0; i < slots.length; i++) {
     var adSlotPosition = slots[i].getTargeting('pos');
 

--- a/src/manager.spec.js
+++ b/src/manager.spec.js
@@ -885,12 +885,24 @@ describe('AdManager', function() {
 
       TestHelper.stub(TargetingPairs, 'getTargetingPairs').returns({});
       TestHelper.stub(AdZone, 'forcedAdZone').returns('');
+      TestHelper.stub(adManager, 'setIndexTargetingForSlots');
 
       stubSlot = { setTargeting: sinon.spy() };
     });
 
     afterEach(function() {
       $(container1).remove();
+    });
+
+    context('> always', function() {
+      beforeEach(function() {
+        TargetingPairs.getTargetingPairs.returns({});
+        adManager.setSlotTargeting(adSlot1, stubSlot, {});
+      });
+
+      it('sets ad index targeting for the slot', function() {
+        expect(adManager.setIndexTargetingForSlots.calledWith([stubSlot])).to.be.true;
+      });
     });
 
     context('> kinja targeting pairs', function() {
@@ -1584,32 +1596,6 @@ describe('AdManager', function() {
   });
 
   describe('#refreshSlots', function() {
-    beforeEach(function() {
-      TestHelper.stub(adManager, 'setIndexTargetingForSlots');
-    });
-
-    context('> always', function() {
-      var adSlot, baseContainer;
-      beforeEach(function(){
-        var setupRefs = adSlotSetup();
-        adSlot = setupRefs.adSlot1;
-        baseContainer = setupRefs.baseContainer;
-        adManager.options.amazonEnabled = false;
-
-        TestHelper.stub(adManager, 'prebidRefresh');
-        TestHelper.stub(adManager, 'fetchAmazonBids');
-      });
-
-      afterEach(function() {
-        $(baseContainer).remove();
-      });
-
-      it('always sets index targeting when an ad refresh is triggered', function() {
-        adManager.refreshSlots([adSlot]);
-        expect(adManager.setIndexTargetingForSlots.calledWith([adSlot])).to.be.true;
-      });
-    });
-
     context('> prebidEnabled', function(){
       var adSlot, baseContainer, stubSlot;
       beforeEach(function(){

--- a/src/manager.spec.js
+++ b/src/manager.spec.js
@@ -24,6 +24,7 @@ describe('AdManager', function() {
       adUnits: adUnits
     });
     adManager.googletag.cmd = [];
+    adManager.countsByAdSlot = {};
   });
 
   afterEach(function() {
@@ -876,6 +877,7 @@ describe('AdManager', function() {
       adSlot1 = document.createElement('div');
       adSlot1.id = 'dfp-ad-1';
       adSlot1.className = 'dfp';
+      adSlot1.setAttribute('data-ad-unit', 'header');
       container1.appendChild(adSlot1);
       document.body.appendChild(container1);
 
@@ -903,7 +905,9 @@ describe('AdManager', function() {
       });
 
       it('- sets targeting for each slot option', function() {
-        expect(stubSlot.setTargeting.callCount).to.equal(2);
+        expect(stubSlot.setTargeting.callCount).to.equal(4);
+        expect(stubSlot.setTargeting.calledWith('pos', 'header')).to.be.true;
+        expect(stubSlot.setTargeting.calledWith('ad_index', '1')).to.be.true;
         expect(stubSlot.setTargeting.calledWith('postId', '1234')).to.be.true;
         expect(stubSlot.setTargeting.calledWith('page', 'permalink')).to.be.true;
       });
@@ -920,7 +924,9 @@ describe('AdManager', function() {
       });
 
       it('- sets all the targeting', function() {
-        expect(stubSlot.setTargeting.callCount).to.equal(2);
+        expect(stubSlot.setTargeting.callCount).to.equal(4);
+        expect(stubSlot.setTargeting.calledWith('pos', 'header')).to.be.true;
+        expect(stubSlot.setTargeting.calledWith('ad_index', '1')).to.be.true;
         expect(stubSlot.setTargeting.calledWith('dfp_content_id', '12345')).to.be.true;
         expect(stubSlot.setTargeting.calledWith('dfp_feature', 'american-voices')).to.be.true;
       });
@@ -943,7 +949,8 @@ describe('AdManager', function() {
       });
 
       it('- sets all the targeting', function() {
-        expect(stubSlot.setTargeting.callCount).to.equal(3);
+        expect(stubSlot.setTargeting.callCount).to.equal(4);
+        expect(stubSlot.setTargeting.calledWith('ad_index', '1')).to.be.true;
         expect(stubSlot.setTargeting.calledWith('pos', 'overridden_pos')).to.be.true;
       });
     });
@@ -953,8 +960,28 @@ describe('AdManager', function() {
         adManager.setSlotTargeting(adSlot1, stubSlot, {});
       });
 
-      it('- sets no targeting', function() {
-        expect(stubSlot.setTargeting.callCount).to.equal(0);
+      it('- sets at least the pos value', function() {
+        expect(stubSlot.setTargeting.callCount).to.equal(2);
+        expect(stubSlot.setTargeting.calledWith('ad_index', '1')).to.be.true;
+        expect(stubSlot.setTargeting.calledWith('pos', 'header')).to.be.true;
+      });
+    });
+
+    context('> ad index targeting', function() {
+      it('- sets ad index targeting to 1, if first ad on the page', function() {
+        adManager.countsByAdSlot = {};
+        adManager.setSlotTargeting(adSlot1, stubSlot, {});
+        expect(stubSlot.setTargeting.callCount).to.equal(2);
+        expect(stubSlot.setTargeting.calledWith('ad_index', '1')).to.be.true;
+      });
+
+      it('- sets ad index targeting to 2, if second ad on page', function() {
+        adManager.countsByAdSlot = {
+          header: 1
+        };
+        adManager.setSlotTargeting(adSlot1, stubSlot, {});
+        expect(stubSlot.setTargeting.callCount).to.equal(2);
+        expect(stubSlot.setTargeting.calledWith('ad_index', '2')).to.be.true;
       });
     });
   });


### PR DESCRIPTION
Added logic to start sending 1-based (instead of starting at 0) index targeting to each of the ad calls on our pages.