### PR TITLE
Fix issue with A9 bids finishing and trying to set targeting before Index is ready

### DIFF
--- a/src/manager.js
+++ b/src/manager.js
@@ -167,7 +167,7 @@ AdManager.prototype.fetchAmazonBids = function (slotsToFetch) {
   }, callback = function (bids) {
     /* Your callback method, in this example it triggers the first DFP request
     for googletag's disableInitialLoad integration after bids have been set */
-    if (indexExchangeEnabled && typeof(window.headertag) !== 'undefined') {
+    if (indexExchangeEnabled && typeof(window.headertag) !== 'undefined' && window.headertag.apiReady) {
       window.headertag.cmd.push(function () {
         window.apstag.setDisplayBids();
       });

--- a/src/manager.spec.js
+++ b/src/manager.spec.js
@@ -1406,6 +1406,8 @@ describe('AdManager', function() {
         }
       };
 
+      headertag.apiReady = true;
+
       window.googletag = {
         cmd: {
           push: function () {


### PR DESCRIPTION
Fixes these errors I've started seeing periodically in Mantle: 
![image](https://user-images.githubusercontent.com/423943/47024617-aeb7a200-d127-11e8-894c-79156d029af5.png)
