### PR TITLE
Ad performance tracking

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,9 +21,9 @@
     "package.json"
   ],
   "dependencies": {
-    "bulbs-public-ads-manager": "https://github.com/theonion/bulbs-public-ads-manager.git#9.10.1"
+    "bulbs-public-ads-manager": "https://github.com/theonion/bulbs-public-ads-manager.git#9.10.0"
   },
   "resolutions": {
-    "bulbs-public-ads-manager": "9.10.1"
+    "bulbs-public-ads-manager": "9.10.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -19,5 +19,8 @@
     "src/**/*.spec.js",
     "**/.*",
     "package.json"
-  ]
+  ],
+  "dependencies": {
+    "bulbs-public-ads-manager": "https://github.com/theonion/bulbs-public-ads-manager.git#9.10.0"
+  }
 }

--- a/bower.json
+++ b/bower.json
@@ -21,6 +21,6 @@
     "package.json"
   ],
   "dependencies": {
-    "bulbs-public-ads-manager": "https://github.com/theonion/bulbs-public-ads-manager.git#9.10.0"
+    "bulbs-public-ads-manager": "https://github.com/theonion/bulbs-public-ads-manager.git#9.9.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -21,6 +21,9 @@
     "package.json"
   ],
   "dependencies": {
-    "bulbs-public-ads-manager": "https://github.com/theonion/bulbs-public-ads-manager.git#9.9.0"
+    "bulbs-public-ads-manager": "https://github.com/theonion/bulbs-public-ads-manager.git#9.10.1"
+  },
+  "resolutions": {
+    "bulbs-public-ads-manager": "9.10.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bulbs-public-ads-manager",
-  "version": "8.2.0",
+  "version": "8.2.1",
   "description": "Do not install via npm.",
   "private": false,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bulbs-public-ads-manager",
-  "version": "8.2.1",
+  "version": "8.2.0",
   "description": "Do not install via npm.",
   "private": false,
   "scripts": {

--- a/src/ad-units.js
+++ b/src/ad-units.js
@@ -1,7 +1,11 @@
 'use strict';
 
+function noop () { }
+
 var AdUnits = {
-  headerSlotRenderEnded: function () {}
+  headerSlotRenderEnded: noop,
+  headerSlotImpressionViewable: noop,
+  headerSlotOnLoad: noop
 };
 
 AdUnits.units = {
@@ -22,6 +26,8 @@ AdUnits.units = {
       [[0, 0], [[1,1], [320, 50], [300, 250], [1280, 720]]]
     ],
     onSlotRenderEnded: AdUnits.headerSlotRenderEnded,
+    onImpressionViewable: AdUnits.headerSlotImpressionViewable,
+    onLoad: AdUnits.headerSlotOnLoad,
     'prebid': {
       'bids': [
         {

--- a/src/ad-units.js
+++ b/src/ad-units.js
@@ -3,9 +3,7 @@
 function noop () { }
 
 var AdUnits = {
-  headerSlotRenderEnded: noop,
-  headerSlotImpressionViewable: noop,
-  headerSlotOnLoad: noop
+  optionalCallback: function () {}
 };
 
 AdUnits.units = {
@@ -25,9 +23,10 @@ AdUnits.units = {
       [[728, 0], [[1,1], [728, 90], [1280, 720]]],
       [[0, 0], [[1,1], [320, 50], [300, 250], [1280, 720]]]
     ],
-    onSlotRenderEnded: AdUnits.headerSlotRenderEnded,
-    onImpressionViewable: AdUnits.headerSlotImpressionViewable,
-    onLoad: AdUnits.headerSlotOnLoad,
+    onSlotRenderEnded: AdUnits.optionalCallback,
+    onImpressionViewable: AdUnits.optionalCallback,
+    onLoad: AdUnits.optionalCallback,
+    onRefresh: AdUnits.optionalCallback,
     'prebid': {
       'bids': [
         {

--- a/src/manager.js
+++ b/src/manager.js
@@ -715,7 +715,7 @@ AdManager.prototype.refreshSlot = function (domElement) {
     this.refreshSlots([slot]);
 
     if (this.adUnits.units[domElement.dataset.adUnit] && this.adUnits.units[domElement.dataset.adUnit].onRefresh) {
-      this.adUnits.units[domElement.dataset.adUnit].onRefresh();
+      this.adUnits.units[domElement.dataset.adUnit].onRefresh(slot, domElement);
     }
   }
 };

--- a/src/manager.js
+++ b/src/manager.js
@@ -289,6 +289,11 @@ AdManager.prototype.onSlotRenderEnded = function (event) {
 AdManager.prototype.onImpressionViewable = function (event) {
   var slotId = event.slot.getSlotId().getDomId();
   var element = document.getElementById(slotId);
+
+  if (this.adUnits.units[element.dataset.adUnit].onImpressionViewable) {
+    this.adUnits.units[element.dataset.adUnit].onImpressionViewable(event, element);
+  }
+  
   utils.dispatchEvent(element, 'dfpImpressionViewable');
 };
 
@@ -301,6 +306,11 @@ AdManager.prototype.onImpressionViewable = function (event) {
 AdManager.prototype.onSlotOnload = function (event) {
   var slotId = event.slot.getSlotId().getDomId();
   var element = document.getElementById(slotId);
+
+  if (this.adUnits.units[element.dataset.adUnit].onLoad) {
+    this.adUnits.units[element.dataset.adUnit].onLoad(event, element);
+  }
+
   utils.dispatchEvent(element, 'dfpSlotOnload');
 };
 
@@ -699,6 +709,10 @@ AdManager.prototype.refreshSlot = function (domElement) {
   if (slot) {
     domElement.setAttribute('data-ad-load-state', 'loading');
     this.refreshSlots([slot], ads);
+
+    if (this.adUnits.units[domElement.dataset.adUnit] && this.adUnits.units[domElement.dataset.adUnit].onRefresh) {
+      this.adUnits.units[domElement.dataset.adUnit].onRefresh();
+    }
   }
 };
 

--- a/src/manager.spec.js
+++ b/src/manager.spec.js
@@ -529,6 +529,8 @@ describe('AdManager', function() {
 
     it('- emits a dfpImpressionViewable event', function() {
       expect(eventSpy).to.have.been.called;
+      TestHelper.stub(adManager.adUnits.units.header, 'onImpressionViewable');
+      adManager.onImpressionViewable(event);
     });
   });
 
@@ -559,6 +561,8 @@ describe('AdManager', function() {
       eventSpy = sinon.spy();
       adElement.addEventListener('dfpSlotOnload', eventSpy);
       adManager.onSlotRenderEnded(event);
+      adManager.onImpressionViewable(event);
+      adManager.onSlotOnload(event);
     });
 
     afterEach(function() {

--- a/src/manager.spec.js
+++ b/src/manager.spec.js
@@ -530,8 +530,12 @@ describe('AdManager', function() {
 
     it('- emits a dfpImpressionViewable event', function() {
       expect(eventSpy).to.have.been.called;
+    });
+
+    it('- should invoke optional onImpressionViewable callback if provided', function () {
       TestHelper.stub(adManager.adUnits.units.header, 'onImpressionViewable');
       adManager.onImpressionViewable(event);
+      expect(adManager.adUnits.units.header.onImpressionViewable.called).to.be.true;
     });
   });
 
@@ -562,8 +566,6 @@ describe('AdManager', function() {
       eventSpy = sinon.spy();
       adElement.addEventListener('dfpSlotOnload', eventSpy);
       adManager.onSlotRenderEnded(event);
-      adManager.onImpressionViewable(event);
-      adManager.onSlotOnload(event);
     });
 
     afterEach(function() {
@@ -572,6 +574,12 @@ describe('AdManager', function() {
 
     it('- emits a dfpSlotOnload event', function() {
       expect(eventSpy).to.have.been.called;
+    });
+
+    it('- should invoke optional onLoad callback if provided', function () {
+      TestHelper.stub(adManager.adUnits.units.header, 'onLoad');
+      adManager.onSlotOnload(event);
+      expect(adManager.adUnits.units.header.onLoad.called).to.be.true;
     });
   });
 
@@ -1529,6 +1537,7 @@ describe('AdManager', function() {
     adSlot1 = document.createElement('div');
     adSlot1.id = 'dfp-ad-1';
     adSlot1.className = 'dfp';
+    adSlot1.dataset.adUnit = 'header';
     container1.appendChild(adSlot1);
     baseContainer.appendChild(container1);
     document.body.appendChild(baseContainer);
@@ -1595,6 +1604,12 @@ describe('AdManager', function() {
 
       adManager.refreshSlot(adSlot);
       expect(adManager.refreshSlots.calledWith([stubSlot])).to.be.true;
+    });
+
+    it('- should invoke optional callback onRefresh if provided', function () {
+      TestHelper.stub(adManager.adUnits.units.header, 'onRefresh');
+      adManager.refreshSlot(adSlot);
+      expect(adManager.adUnits.units.header.onRefresh.called).to.be.true;
     });
 
   });


### PR DESCRIPTION
Adds optional callback methods for `slotOnImpressionViewable`, `slotOnLoad` and `slotOnRefresh` to invoke when correlating event fires. 

Correlates with gawkermedia/kinja-mantle#16139