### PR TITLE
check for activeSizes in `refreshSlot`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bulbs-public-ads-manager",
-  "version": "9.11.0",
+  "version": "9.11.1",
   "description": "Ads manager for public side.",
   "private": false,
   "scripts": {

--- a/src/manager.js
+++ b/src/manager.js
@@ -710,7 +710,7 @@ AdManager.prototype.refreshSlot = function (domElement) {
 
   var slot = this.slots[domElement.id];
 
-  if (slot) {
+  if (slot && slot.activeSizes && slot.activeSizes.length) {
     domElement.setAttribute('data-ad-load-state', 'loading');
     this.refreshSlots([slot]);
 


### PR DESCRIPTION
Mobile posts won't refresh if there are no active sizes