### PR TITLE
check for `outOfPage` conditional on refreshSlot

### DIFF
--- a/src/manager.js
+++ b/src/manager.js
@@ -710,7 +710,7 @@ AdManager.prototype.refreshSlot = function (domElement) {
 
   var slot = this.slots[domElement.id];
 
-  if (slot && slot.activeSizes && slot.activeSizes.length) {
+  if (slot && (slot.getOutOfPage() || (slot.activeSizes && slot.activeSizes.length))) {
     domElement.setAttribute('data-ad-load-state', 'loading');
     this.refreshSlots([slot]);
 

--- a/src/manager.spec.js
+++ b/src/manager.spec.js
@@ -1554,7 +1554,8 @@ describe('AdManager', function() {
       getTargeting: function () {
         return '';
       },
-      setTargeting: function () {}
+      setTargeting: function () {},
+      getOutOfPage: function () { return false; }
     };
     variableReferences = {
       baseContainer: baseContainer,


### PR DESCRIPTION
Fixes a bug to check for slot `outOfPage` method condition in addition to `activeSizes`