### PR TITLE
refactor es6 syntax

### DIFF
--- a/src/helpers/TargetingPairs.js
+++ b/src/helpers/TargetingPairs.js
@@ -39,8 +39,10 @@ var TargetingPairs = {
   */
   getArticlePosition: function (adContainer, kinjaMeta) {
     if (document && adContainer && kinjaMeta.pageType === "permalink" && !(kinjaMeta.post && kinjaMeta.post.isFeatured)) {
-      var readingListPostIds = Array.from(document.getElementsByClassName('js_reading-list-item')).map(post => post.dataset.postId);
-      
+      var readingListPostIds = Array.from(document.getElementsByClassName('js_reading-list-item')).map(function(post) {
+        return post.dataset.postId;
+      });
+
       if (readingListPostIds.length > 0) {
         var readingListItem = adContainer.closest('.js_reading-list-item');
         if (readingListItem) {


### PR DESCRIPTION
missed this, and nowhere in our pipeline does it err until jenkins tries to build with it.

not worth adding checks to prevent this at this point since we're migrating this to mantle, which will let us bundle it like other js packages. so for now, just have to be more careful